### PR TITLE
Stop scanning when cancelling the subscription

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ StreamSubscription scanSubscription = flutterBlue.startScan().listen((scanResult
 });
 
 /// Stop scanning
-flutterBlue.stopScan();
+scanSubscription.cancel();
 ```
 
 ### Connect to a device


### PR DESCRIPTION
Hey hey :) Cool library!

Rando Q turned into a PR -- I was reading through the README, and thought it was a bit funny that you start listening to the Stream and store the subscription, but then never cancel the subscription. It seems that simply doing a `stopScan()` without `cancel`ing the subscription could lead to some hard to find bugs.

Therefore, I changed up the `startScan` method to return a stream that will automatically call `stopScan` when you cancel the subscription. I changed up the example to reflect this change / show the difference. This gives us the best of both worlds: It ends the streams AND the channel in one command!

Anyhow, lemme know whatcha think / if it makes sense! Feel free to merge or ignore :)