### PR TITLE
connect() subscription and automatic disconnect, rename startScan to scan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 0.2.2
-* BREAKING CHANGE: `ScanResult` now returns a `BluetoothDevice`
+* BREAKING CHANGES
+* `startScan` renamed to `scan`
+* `ScanResult` now returns a `BluetoothDevice`
+* `connect()` now takes a `BluetoothDevice` and returns Stream<BluetoothDeviceState>
+* Automatic disconnect on deviceConnection.cancel()
 
 ## 0.2.1
 * BREAKING CHANGE: removed `stopScan` from API, use `scanSubscription.cancel()` instead

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.2.2
+* BREAKING CHANGE: `ScanResult` now returns a `BluetoothDevice`
+
 ## 0.2.1
 * BREAKING CHANGE: removed `stopScan` from API, use `scanSubscription.cancel()` instead
 * Automatically stops scan when `startScan` subscription is canceled (thanks to @brianegan)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 * BREAKING CHANGES
 * `startScan` renamed to `scan`
 * `ScanResult` now returns a `BluetoothDevice`
-* `connect()` now takes a `BluetoothDevice` and returns Stream<BluetoothDeviceState>
+* `connect` now takes a `BluetoothDevice` and returns Stream<BluetoothDeviceState>
+* Added parameter `timeout` to `connect`
 * Automatic disconnect on deviceConnection.cancel()
 
 ## 0.2.1

--- a/README.md
+++ b/README.md
@@ -36,13 +36,14 @@ scanSubscription.cancel();
 
 ### Connect to a device
 ```dart
+/// Create a connection to the device
 var deviceConnection = flutterBlue.connect(device).listen((s) {
     if(s == BluetoothDeviceState.connected) {
         // device is connected, do something
     }
 });
 
-// Disconnect from device
+/// Disconnect from device
 deviceConnection.cancel();
 ```
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ FlutterBlue flutterBlue = FlutterBlue.instance;
 ### Scan for devices
 ```dart
 /// Start scanning
-StreamSubscription scanSubscription = flutterBlue.startScan().listen((scanResult) {
+var scanSubscription = flutterBlue.scan().listen((scanResult) {
     // do something with scan result
 });
 
@@ -36,7 +36,14 @@ scanSubscription.cancel();
 
 ### Connect to a device
 ```dart
-BluetoothDevice device = await flutterBlue.connect(scanResult.device.id);
+var deviceConnection = flutterBlue.connect(device).listen((s) {
+    if(s == BluetoothDeviceState.connected) {
+        // device is connected, do something
+    }
+});
+
+// Disconnect from device
+deviceConnection.cancel();
 ```
 
 ### Discover services
@@ -85,9 +92,8 @@ device.onValueChanged(characteristic).listen((value) {
 ### FlutterBlue API
 |                  |      Android       |         iOS          |             Description            |
 | :--------------- | :----------------: | :------------------: |  :-------------------------------- |
-| startScan        | :white_check_mark: | :white_large_square: | Starts a scan for Bluetooth Low Energy devices. |
+| scan             | :white_check_mark: | :white_large_square: | Starts a scan for Bluetooth Low Energy devices. |
 | connect          | :white_check_mark: | :white_large_square: | Establishes a connection to the Bluetooth Device. |
-| cancelConnection | :white_check_mark: | :white_large_square: | Cancels a connection to the Bluetooth Device. |
 | state            | :white_check_mark: | :white_large_square: | Gets the current state of the Bluetooth Adapter. |
 | onStateChanged   | :white_check_mark: | :white_large_square: | Stream of state changes for the Bluetooth Adapter. |
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ scanSubscription.cancel();
 
 ### Connect to a device
 ```dart
-BluetoothDevice device = await flutterBlue.connect(scanResult.identifier);
+BluetoothDevice device = await flutterBlue.connect(scanResult.device.id);
 ```
 
 ### Discover services

--- a/android/src/main/java/com/pauldemarco/flutterblue/FlutterBluePlugin.java
+++ b/android/src/main/java/com/pauldemarco/flutterblue/FlutterBluePlugin.java
@@ -592,15 +592,9 @@ public class FlutterBluePlugin implements MethodCallHandler {
                 @Override
                 public void onScanResult(int callbackType, ScanResult result) {
                     super.onScanResult(callbackType, result);
-                    Protos.ScanResult.Builder scanResult = Protos.ScanResult.newBuilder()
-                            .setRemoteId(result.getDevice().getAddress())
-                            .setName(result.getDevice().getName())
-                            .setRssi(result.getRssi());
-                    if(result.getScanRecord() != null) {
-                        scanResult.setAdvertisementData(AdvertisementParser.parse(result.getScanRecord().getBytes()));
-                    }
                     if(scanResultsSink != null) {
-                        scanResultsSink.success(scanResult.build().toByteArray());
+                        Protos.ScanResult scanResult = ProtoMaker.from(result.getDevice(), result.getScanRecord().getBytes(), result.getRssi());
+                        scanResultsSink.success(scanResult.toByteArray());
                     }
                 }
 
@@ -637,13 +631,8 @@ public class FlutterBluePlugin implements MethodCallHandler {
                 @Override
                 public void onLeScan(final BluetoothDevice bluetoothDevice, int rssi,
                                      byte[] scanRecord) {
-                    Protos.ScanResult scanResult = Protos.ScanResult.newBuilder()
-                            .setRemoteId(bluetoothDevice.getAddress())
-                            .setName(bluetoothDevice.getName())
-                            .setRssi(rssi)
-                            .setAdvertisementData(AdvertisementParser.parse(scanRecord))
-                            .build();
                     if(scanResultsSink != null) {
+                        Protos.ScanResult scanResult = ProtoMaker.from(bluetoothDevice, scanRecord, rssi);
                         scanResultsSink.success(scanResult.toByteArray());
                     }
                 }

--- a/android/src/main/java/com/pauldemarco/flutterblue/FlutterBluePlugin.java
+++ b/android/src/main/java/com/pauldemarco/flutterblue/FlutterBluePlugin.java
@@ -58,7 +58,6 @@ public class FlutterBluePlugin implements MethodCallHandler {
     private final EventChannel characteristicNotifiedChannel;
     private final BluetoothManager mBluetoothManager;
     private BluetoothAdapter mBluetoothAdapter;
-    private final Map<String, Result> mConnectionRequests = new HashMap<>();
     private final Map<String, BluetoothGatt> mGattServers = new HashMap<>();
 
     /**
@@ -187,20 +186,10 @@ public class FlutterBluePlugin implements MethodCallHandler {
                     }
                 }
 
-                // If the device is completely new, connect and add to list
-                if(!mGattServers.containsKey(deviceId)){
-                    BluetoothGatt gattServer = device.connectGatt(registrar.activity(), options.getAndroidAutoConnect(), mGattCallback);
-                    mGattServers.put(deviceId, gattServer);
-                }
-
-                // Update the connection requests list with this Result instance
-                synchronized (mConnectionRequests) {
-                    Result r = mConnectionRequests.remove(deviceId);
-                    if(r != null) {
-                        r.error("connect_cancelled", "another connection attempt to this device has started", null);
-                    }
-                    mConnectionRequests.put(deviceId, result);
-                }
+                // New request, connect and add gattServer to Map
+                BluetoothGatt gattServer = device.connectGatt(registrar.activity(), options.getAndroidAutoConnect(), mGattCallback);
+                mGattServers.put(deviceId, gattServer);
+                result.success(null);
                 break;
             }
 
@@ -210,12 +199,6 @@ public class FlutterBluePlugin implements MethodCallHandler {
                 BluetoothGatt gattServer = mGattServers.remove(deviceId);
                 if(gattServer != null) {
                     gattServer.close();
-                }
-                synchronized (mConnectionRequests) {
-                    Result r = mConnectionRequests.remove(deviceId);
-                    if(r != null) {
-                        r.error("connect_cancelled", "the connect request was cancelled", null);
-                    }
                 }
                 result.success(null);
                 break;
@@ -718,29 +701,7 @@ public class FlutterBluePlugin implements MethodCallHandler {
         @Override
         public void onConnectionStateChange(BluetoothGatt gatt, int status, int newState) {
             Log.d(TAG, "onConnectionStateChange: ");
-            synchronized (mConnectionRequests) {
-                Result result = mConnectionRequests.remove(gatt.getDevice().getAddress());
-                if(result != null) {
-                    if(status == BluetoothGatt.GATT_SUCCESS && newState == BluetoothProfile.STATE_CONNECTED) {
-                        final Protos.BluetoothDevice p = Protos.BluetoothDevice.newBuilder()
-                                .setName(gatt.getDevice().getName())
-                                .setRemoteId(gatt.getDevice().getAddress())
-                                .setType(Protos.BluetoothDevice.Type.forNumber(gatt.getDevice().getType()))
-                                .build();
-                        result.success(p.toByteArray());
-                    } else if(status == BluetoothGatt.GATT_SUCCESS && newState == BluetoothProfile.STATE_DISCONNECTED) {
-                        result.error("connect_cancelled", "the device has been disconnected", null);
-                    } else {
-                        result.error("connect_error", "Error in BluetoothGattCallback, status:" + status + " newState:" + newState, null);
-                    }
-                }
-            }
-            // Main method call, for onStateChanged streams
-            try {
-                channel.invokeMethod("DeviceState", ProtoMaker.from(gatt.getDevice(), newState).toByteArray());
-            } catch (Exception e) {
-                e.printStackTrace();
-            }
+            channel.invokeMethod("DeviceState", ProtoMaker.from(gatt.getDevice(), newState).toByteArray());
         }
 
         @Override

--- a/android/src/main/java/com/pauldemarco/flutterblue/FlutterBluePlugin.java
+++ b/android/src/main/java/com/pauldemarco/flutterblue/FlutterBluePlugin.java
@@ -162,9 +162,9 @@ public class FlutterBluePlugin implements MethodCallHandler {
             case "connect":
             {
                 byte[] data = call.arguments();
-                Protos.ConnectOptions options;
+                Protos.ConnectRequest options;
                 try {
-                    options = Protos.ConnectOptions.newBuilder().mergeFrom(data).build();
+                    options = Protos.ConnectRequest.newBuilder().mergeFrom(data).build();
                 } catch (InvalidProtocolBufferException e) {
                     result.error("RuntimeException", e.getMessage(), e);
                     break;

--- a/android/src/main/java/com/pauldemarco/flutterblue/ProtoMaker.java
+++ b/android/src/main/java/com/pauldemarco/flutterblue/ProtoMaker.java
@@ -23,6 +23,36 @@ public class ProtoMaker {
 
     private static final UUID CCCD_UUID = UUID.fromString("000002902-0000-1000-8000-00805f9b34fb");
 
+    static Protos.ScanResult from(BluetoothDevice device, byte[] advertisementData, int rssi) {
+        Protos.ScanResult.Builder p = Protos.ScanResult.newBuilder();
+        p.setDevice(from(device));
+        if(advertisementData != null && advertisementData.length > 0)
+            p.setAdvertisementData(AdvertisementParser.parse(advertisementData));
+        p.setRssi(rssi);
+        return p.build();
+    }
+
+    static Protos.BluetoothDevice from(BluetoothDevice device) {
+        Protos.BluetoothDevice.Builder p = Protos.BluetoothDevice.newBuilder();
+        p.setRemoteId(device.getAddress());
+        p.setName(device.getName());
+        switch(device.getType()){
+            case BluetoothDevice.DEVICE_TYPE_LE:
+                p.setType(Protos.BluetoothDevice.Type.LE);
+                break;
+            case BluetoothDevice.DEVICE_TYPE_CLASSIC:
+                p.setType(Protos.BluetoothDevice.Type.CLASSIC);
+                break;
+            case BluetoothDevice.DEVICE_TYPE_DUAL:
+                p.setType(Protos.BluetoothDevice.Type.DUAL);
+                break;
+            default:
+                p.setType(Protos.BluetoothDevice.Type.UNKNOWN);
+                break;
+        }
+        return p.build();
+    }
+
     static Protos.BluetoothService from(BluetoothDevice device, BluetoothGattService service, BluetoothGatt gatt) {
         Protos.BluetoothService.Builder p = Protos.BluetoothService.newBuilder();
         p.setRemoteId(device.getAddress());

--- a/android/src/main/java/com/pauldemarco/flutterblue/ProtoMaker.java
+++ b/android/src/main/java/com/pauldemarco/flutterblue/ProtoMaker.java
@@ -118,7 +118,7 @@ public class ProtoMaker {
                 .build();
     }
 
-    static Protos.DeviceStateResponse from(BluetoothDevice device, int state) throws Exception {
+    static Protos.DeviceStateResponse from(BluetoothDevice device, int state) {
         Protos.DeviceStateResponse.Builder p = Protos.DeviceStateResponse.newBuilder();
         switch(state) {
             case BluetoothProfile.STATE_DISCONNECTING:
@@ -134,7 +134,7 @@ public class ProtoMaker {
                 p.setState(Protos.DeviceStateResponse.BluetoothDeviceState.DISCONNECTED);
                 break;
             default:
-                throw new Exception("device state is unknown");
+                break;
         }
         p.setRemoteId(device.getAddress());
         return p.build();

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -35,7 +35,7 @@ class _FlutterBlueAppState extends State<FlutterBlueApp> {
   /// Device
   BluetoothDevice device;
   bool get isConnected => (device != null);
-  StreamSubscription connectionSubscription;
+  StreamSubscription deviceConnection;
   List<BluetoothService> services = new List();
   StreamSubscription<List<int>> valueChangedSubscription;
   BluetoothDeviceState deviceState = BluetoothDeviceState.disconnected;
@@ -63,14 +63,14 @@ class _FlutterBlueAppState extends State<FlutterBlueApp> {
     _stateSubscription = null;
     _scanSubscription?.cancel();
     _scanSubscription = null;
-    connectionSubscription?.cancel();
-    connectionSubscription = null;
+    deviceConnection?.cancel();
+    deviceConnection = null;
     super.dispose();
   }
 
   _startScan() {
     _scanSubscription = _flutterBlue
-        .startScan(timeout: const Duration(seconds: 5))
+        .scan(timeout: const Duration(seconds: 5))
         .listen((scanResult) {
       setState(() {
         scanResults[scanResult.device.id] = scanResult;
@@ -93,7 +93,7 @@ class _FlutterBlueAppState extends State<FlutterBlueApp> {
   _connect(BluetoothDevice d) async {
     device = d;
     // Connect to device
-    connectionSubscription = _flutterBlue.connect(device).listen(null);
+    deviceConnection = _flutterBlue.connect(device).listen(null);
 
     // Update the connection state immediately
     device.state.then((s) {
@@ -118,8 +118,8 @@ class _FlutterBlueAppState extends State<FlutterBlueApp> {
   }
 
   _disconnect() {
-    connectionSubscription?.cancel();
-    connectionSubscription = null;
+    deviceConnection?.cancel();
+    deviceConnection = null;
     setState(() {
       device = null;
     });

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -93,7 +93,12 @@ class _FlutterBlueAppState extends State<FlutterBlueApp> {
   _connect(BluetoothDevice d) async {
     device = d;
     // Connect to device
-    deviceConnection = _flutterBlue.connect(device, timeout: const Duration(seconds: 2)).listen(null, onDone: _disconnect);
+    deviceConnection = _flutterBlue
+        .connect(device, timeout: const Duration(seconds: 4))
+        .listen(
+          null,
+          onDone: _disconnect,
+        );
 
     // Update the connection state immediately
     device.state.then((s) {
@@ -107,7 +112,7 @@ class _FlutterBlueAppState extends State<FlutterBlueApp> {
       setState(() {
         deviceState = s;
       });
-      if(s == BluetoothDeviceState.connected) {
+      if (s == BluetoothDeviceState.connected) {
         device.discoverServices().then((s) {
           setState(() {
             services = s;

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -70,7 +70,7 @@ class _FlutterBlueAppState extends State<FlutterBlueApp> {
         .startScan(timeout: const Duration(seconds: 5))
         .listen((scanResult) {
       setState(() {
-        scanResults[scanResult.identifier] = scanResult;
+        scanResults[scanResult.device.id] = scanResult;
       });
     }, onDone: _stopScan);
 
@@ -89,7 +89,7 @@ class _FlutterBlueAppState extends State<FlutterBlueApp> {
 
   _connect(ScanResult r) async {
     // Connect to device
-    BluetoothDevice d = await _flutterBlue.connect(r.identifier);
+    BluetoothDevice d = await _flutterBlue.connect(r.device.id);
     setState(() {
       device = d;
     });
@@ -183,8 +183,8 @@ class _FlutterBlueAppState extends State<FlutterBlueApp> {
   _buildScanResultTiles(BuildContext context) {
     return scanResults.values
         .map((s) => new ListTile(
-              title: new Text(s.name),
-              subtitle: new Text(s.identifier.toString()),
+              title: new Text(s.device.name),
+              subtitle: new Text(s.device.id.toString()),
               leading: new Text(s.rssi.toString()),
               onTap: () => _connect(s),
             ))

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -93,7 +93,7 @@ class _FlutterBlueAppState extends State<FlutterBlueApp> {
   _connect(BluetoothDevice d) async {
     device = d;
     // Connect to device
-    deviceConnection = _flutterBlue.connect(device).listen(null);
+    deviceConnection = _flutterBlue.connect(device, timeout: const Duration(seconds: 2)).listen(null, onDone: _disconnect);
 
     // Update the connection state immediately
     device.state.then((s) {

--- a/lib/gen/flutterblue.pb.dart
+++ b/lib/gen/flutterblue.pb.dart
@@ -206,27 +206,27 @@ class ScanResult extends GeneratedMessage {
 
 class _ReadonlyScanResult extends ScanResult with ReadonlyMessageMixin {}
 
-class ConnectOptions extends GeneratedMessage {
-  static final BuilderInfo _i = new BuilderInfo('ConnectOptions')
+class ConnectRequest extends GeneratedMessage {
+  static final BuilderInfo _i = new BuilderInfo('ConnectRequest')
     ..a<String>(1, 'remoteId', PbFieldType.OS)
     ..a<bool>(2, 'androidAutoConnect', PbFieldType.OB)
     ..hasRequiredFields = false
   ;
 
-  ConnectOptions() : super();
-  ConnectOptions.fromBuffer(List<int> i, [ExtensionRegistry r = ExtensionRegistry.EMPTY]) : super.fromBuffer(i, r);
-  ConnectOptions.fromJson(String i, [ExtensionRegistry r = ExtensionRegistry.EMPTY]) : super.fromJson(i, r);
-  ConnectOptions clone() => new ConnectOptions()..mergeFromMessage(this);
+  ConnectRequest() : super();
+  ConnectRequest.fromBuffer(List<int> i, [ExtensionRegistry r = ExtensionRegistry.EMPTY]) : super.fromBuffer(i, r);
+  ConnectRequest.fromJson(String i, [ExtensionRegistry r = ExtensionRegistry.EMPTY]) : super.fromJson(i, r);
+  ConnectRequest clone() => new ConnectRequest()..mergeFromMessage(this);
   BuilderInfo get info_ => _i;
-  static ConnectOptions create() => new ConnectOptions();
-  static PbList<ConnectOptions> createRepeated() => new PbList<ConnectOptions>();
-  static ConnectOptions getDefault() {
-    if (_defaultInstance == null) _defaultInstance = new _ReadonlyConnectOptions();
+  static ConnectRequest create() => new ConnectRequest();
+  static PbList<ConnectRequest> createRepeated() => new PbList<ConnectRequest>();
+  static ConnectRequest getDefault() {
+    if (_defaultInstance == null) _defaultInstance = new _ReadonlyConnectRequest();
     return _defaultInstance;
   }
-  static ConnectOptions _defaultInstance;
-  static void $checkItem(ConnectOptions v) {
-    if (v is! ConnectOptions) checkItemFailed(v, 'ConnectOptions');
+  static ConnectRequest _defaultInstance;
+  static void $checkItem(ConnectRequest v) {
+    if (v is! ConnectRequest) checkItemFailed(v, 'ConnectRequest');
   }
 
   String get remoteId => $_get(0, 1, '');
@@ -240,7 +240,7 @@ class ConnectOptions extends GeneratedMessage {
   void clearAndroidAutoConnect() => clearField(2);
 }
 
-class _ReadonlyConnectOptions extends ConnectOptions with ReadonlyMessageMixin {}
+class _ReadonlyConnectRequest extends ConnectRequest with ReadonlyMessageMixin {}
 
 class BluetoothDevice extends GeneratedMessage {
   static final BuilderInfo _i = new BuilderInfo('BluetoothDevice')

--- a/lib/gen/flutterblue.pb.dart
+++ b/lib/gen/flutterblue.pb.dart
@@ -166,10 +166,9 @@ class _ReadonlyScanSettings extends ScanSettings with ReadonlyMessageMixin {}
 
 class ScanResult extends GeneratedMessage {
   static final BuilderInfo _i = new BuilderInfo('ScanResult')
-    ..a<String>(1, 'remoteId', PbFieldType.OS)
-    ..a<String>(2, 'name', PbFieldType.OS)
+    ..a<BluetoothDevice>(1, 'device', PbFieldType.OM, BluetoothDevice.getDefault, BluetoothDevice.create)
+    ..a<AdvertisementData>(2, 'advertisementData', PbFieldType.OM, AdvertisementData.getDefault, AdvertisementData.create)
     ..a<int>(3, 'rssi', PbFieldType.O3)
-    ..a<AdvertisementData>(4, 'advertisementData', PbFieldType.OM, AdvertisementData.getDefault, AdvertisementData.create)
     ..hasRequiredFields = false
   ;
 
@@ -189,25 +188,20 @@ class ScanResult extends GeneratedMessage {
     if (v is! ScanResult) checkItemFailed(v, 'ScanResult');
   }
 
-  String get remoteId => $_get(0, 1, '');
-  set remoteId(String v) { $_setString(0, 1, v); }
-  bool hasRemoteId() => $_has(0, 1);
-  void clearRemoteId() => clearField(1);
+  BluetoothDevice get device => $_get(0, 1, null);
+  set device(BluetoothDevice v) { setField(1, v); }
+  bool hasDevice() => $_has(0, 1);
+  void clearDevice() => clearField(1);
 
-  String get name => $_get(1, 2, '');
-  set name(String v) { $_setString(1, 2, v); }
-  bool hasName() => $_has(1, 2);
-  void clearName() => clearField(2);
+  AdvertisementData get advertisementData => $_get(1, 2, null);
+  set advertisementData(AdvertisementData v) { setField(2, v); }
+  bool hasAdvertisementData() => $_has(1, 2);
+  void clearAdvertisementData() => clearField(2);
 
   int get rssi => $_get(2, 3, 0);
   set rssi(int v) { $_setUnsignedInt32(2, 3, v); }
   bool hasRssi() => $_has(2, 3);
   void clearRssi() => clearField(3);
-
-  AdvertisementData get advertisementData => $_get(3, 4, null);
-  set advertisementData(AdvertisementData v) { setField(4, v); }
-  bool hasAdvertisementData() => $_has(3, 4);
-  void clearAdvertisementData() => clearField(4);
 }
 
 class _ReadonlyScanResult extends ScanResult with ReadonlyMessageMixin {}

--- a/lib/gen/flutterblue.pbjson.dart
+++ b/lib/gen/flutterblue.pbjson.dart
@@ -64,8 +64,8 @@ const ScanResult$json = const {
   ],
 };
 
-const ConnectOptions$json = const {
-  '1': 'ConnectOptions',
+const ConnectRequest$json = const {
+  '1': 'ConnectRequest',
   '2': const [
     const {'1': 'remote_id', '3': 1, '4': 1, '5': 9, '10': 'remoteId'},
     const {'1': 'android_auto_connect', '3': 2, '4': 1, '5': 8, '10': 'androidAutoConnect'},

--- a/lib/gen/flutterblue.pbjson.dart
+++ b/lib/gen/flutterblue.pbjson.dart
@@ -58,10 +58,9 @@ const ScanSettings$json = const {
 const ScanResult$json = const {
   '1': 'ScanResult',
   '2': const [
-    const {'1': 'remote_id', '3': 1, '4': 1, '5': 9, '10': 'remoteId'},
-    const {'1': 'name', '3': 2, '4': 1, '5': 9, '10': 'name'},
+    const {'1': 'device', '3': 1, '4': 1, '5': 11, '6': '.BluetoothDevice', '10': 'device'},
+    const {'1': 'advertisement_data', '3': 2, '4': 1, '5': 11, '6': '.AdvertisementData', '10': 'advertisementData'},
     const {'1': 'rssi', '3': 3, '4': 1, '5': 5, '10': 'rssi'},
-    const {'1': 'advertisement_data', '3': 4, '4': 1, '5': 11, '6': '.AdvertisementData', '10': 'advertisementData'},
   ],
 };
 

--- a/lib/src/flutter_blue.dart
+++ b/lib/src/flutter_blue.dart
@@ -47,7 +47,7 @@ class FlutterBlue {
   }
 
   /// Starts a scan for Bluetooth Low Energy devices
-  Stream<ScanResult> startScan({
+  Stream<ScanResult> scan({
     ScanMode scanMode = ScanMode.lowLatency,
     List<Guid> withServices = const [],
     List<Guid> withDevices = const [],

--- a/lib/src/flutter_blue.dart
+++ b/lib/src/flutter_blue.dart
@@ -98,10 +98,7 @@ class FlutterBlue {
       subscription.cancel();
     });
 
-    await _channel
-        .invokeMethod('connect', request.writeToBuffer())
-        .then((List<int> data) => new protos.BluetoothDevice.fromBuffer(data))
-        .then((d) => new BluetoothDevice.fromProto(d));
+    await _channel.invokeMethod('connect', request.writeToBuffer());
 
     subscription = device.onStateChanged().listen(
       controller.add,

--- a/lib/src/flutter_blue.dart
+++ b/lib/src/flutter_blue.dart
@@ -141,16 +141,14 @@ class DeviceIdentifier {
 
 class ScanResult {
   const ScanResult(
-      {this.name, this.identifier, this.advertisementData, this.rssi});
+      {this.device, this.advertisementData, this.rssi});
 
   ScanResult.fromProto(protos.ScanResult p)
-      : name = p.name,
-        identifier = new DeviceIdentifier(p.remoteId),
-        rssi = p.rssi,
-        advertisementData = new AdvertisementData.fromProto(p.advertisementData);
+      : device = new BluetoothDevice.fromProto(p.device),
+        advertisementData = new AdvertisementData.fromProto(p.advertisementData),
+        rssi = p.rssi;
 
-  final String name;
-  final DeviceIdentifier identifier;
+  final BluetoothDevice device;
   final AdvertisementData advertisementData;
   final int rssi;
 }

--- a/protos/flutterblue.proto
+++ b/protos/flutterblue.proto
@@ -40,7 +40,7 @@ message ScanResult {
   int32 rssi = 3;
 }
 
-message ConnectOptions {
+message ConnectRequest {
   string remote_id = 1;
   bool android_auto_connect = 2;
 }

--- a/protos/flutterblue.proto
+++ b/protos/flutterblue.proto
@@ -35,10 +35,9 @@ message ScanSettings {
 }
 
 message ScanResult {
-  string remote_id = 1;  // The received peer's ID.
-  string name = 2;  // The peer's name.
+  BluetoothDevice device = 1;  // The received peer's ID.
+  AdvertisementData advertisement_data = 2;
   int32 rssi = 3;
-  AdvertisementData advertisement_data = 4;
 }
 
 message ConnectOptions {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_blue
 description: Bluetooth plugin for Flutter
-version: 0.2.1
+version: 0.2.2
 author: Paul DeMarco <paulmdemarco@gmail.com>
 homepage: https://github.com/pauldemarco/flutter_blue
 


### PR DESCRIPTION
Fixes issue #18 #19 

- `startScan` renamed to simply `scan`
- `ScanResult` now includes `BluetoothDevice`
- `connect` now takes a `BluetoothDevice` as a parameter and returns a `Stream<BluetoothDeviceState>`
- `deviceConnection.cancel()` automatically disconnects from device