### PR TITLE
Queue GATT operations, refactor reply channels

### DIFF
--- a/android/src/main/java/com/pauldemarco/flutterblue/DiscoverServicesOperation.java
+++ b/android/src/main/java/com/pauldemarco/flutterblue/DiscoverServicesOperation.java
@@ -1,0 +1,35 @@
+// Copyright 2018, Daniel Turing.
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+package com.pauldemarco.flutterblue;
+
+import android.bluetooth.BluetoothGatt;
+import android.bluetooth.BluetoothGattService;
+import io.flutter.plugin.common.MethodChannel.Result;
+
+public class DiscoverServicesOperation extends GattOperation {
+
+    public DiscoverServicesOperation(BluetoothGatt g,  Result r, GattOperation.FinishedCallback f) {
+        super(g,r,f);
+    }
+
+    public void execute() {
+        if(!mGattServer.discoverServices()) {
+            mResult.error("discover_services_error", "unknown reason", null);
+            finished();
+        }
+    }
+
+    @Override
+    public void onServicesDiscovered(BluetoothGatt gatt, int status) {
+        Protos.DiscoverServicesResult.Builder p = Protos.DiscoverServicesResult.newBuilder();
+        p.setRemoteId(mGattServer.getDevice().getAddress());
+        for(BluetoothGattService s : mGattServer.getServices()) {
+            p.addServices(ProtoMaker.from(mGattServer.getDevice(), s, mGattServer));
+        }
+        mResult.success(p.build().toByteArray());
+
+        finished();
+    }
+}

--- a/android/src/main/java/com/pauldemarco/flutterblue/FlutterBluePlugin.java
+++ b/android/src/main/java/com/pauldemarco/flutterblue/FlutterBluePlugin.java
@@ -30,6 +30,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentLinkedQueue;
 
 import io.flutter.plugin.common.EventChannel;
 import io.flutter.plugin.common.EventChannel.EventSink;
@@ -40,25 +41,22 @@ import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
 import io.flutter.plugin.common.MethodChannel.Result;
 import io.flutter.plugin.common.PluginRegistry.Registrar;
 
-
 /**
  * FlutterBluePlugin
  */
-public class FlutterBluePlugin implements MethodCallHandler {
+public class FlutterBluePlugin implements MethodCallHandler, GattOperation.FinishedCallback {
     private static final String TAG = "FlutterBluePlugin";
     private static final String NAMESPACE = "plugins.pauldemarco.com/flutter_blue";
-    static final private UUID CCCD_ID = UUID.fromString("000002902-0000-1000-8000-00805f9b34fb");
     private final Registrar registrar;
     private final MethodChannel channel;
     private final EventChannel stateChannel;
     private final EventChannel scanResultChannel;
-    private final EventChannel servicesDiscoveredChannel;
-    private final EventChannel characteristicReadChannel;
-    private final EventChannel descriptorReadChannel;
-    private final EventChannel characteristicNotifiedChannel;
     private final BluetoothManager mBluetoothManager;
     private BluetoothAdapter mBluetoothAdapter;
     private final Map<String, BluetoothGatt> mGattServers = new HashMap<>();
+
+    private ConcurrentLinkedQueue<GattOperation> mQueue;
+    private GattOperation mCurrentOperation;
 
     /**
      * Plugin registration.
@@ -72,19 +70,37 @@ public class FlutterBluePlugin implements MethodCallHandler {
         this.channel = new MethodChannel(registrar.messenger(), NAMESPACE+"/methods");
         this.stateChannel = new EventChannel(registrar.messenger(), NAMESPACE+"/state");
         this.scanResultChannel = new EventChannel(registrar.messenger(), NAMESPACE+"/scanResult");
-        this.servicesDiscoveredChannel = new EventChannel(registrar.messenger(), NAMESPACE+"/servicesDiscovered");
-        this.characteristicReadChannel = new EventChannel(registrar.messenger(), NAMESPACE+"/characteristicRead");
-        this.descriptorReadChannel = new EventChannel(registrar.messenger(), NAMESPACE+"/descriptorRead");
-        this.characteristicNotifiedChannel = new EventChannel(registrar.messenger(), NAMESPACE+"/characteristicNotified");
         this.mBluetoothManager = (BluetoothManager) r.activity().getSystemService(Context.BLUETOOTH_SERVICE);
         this.mBluetoothAdapter = mBluetoothManager.getAdapter();
         channel.setMethodCallHandler(this);
         stateChannel.setStreamHandler(stateHandler);
         scanResultChannel.setStreamHandler(scanResultsHandler);
-        servicesDiscoveredChannel.setStreamHandler(servicesDiscoveredHandler);
-        characteristicReadChannel.setStreamHandler(characteristicReadHandler);
-        descriptorReadChannel.setStreamHandler(descriptorReadHandler);
-        characteristicNotifiedChannel.setStreamHandler(characteristicNotifiedHandler);
+
+        mQueue = new ConcurrentLinkedQueue<>();
+    }
+
+    private void queueOperation(GattOperation op) {
+        mQueue.add(op);
+        driveQueue();
+    }
+
+    private void driveQueue() {
+        if (mCurrentOperation!=null) {
+            return;
+        }
+        if (mQueue.size() == 0) {
+            return;
+        }
+
+        final GattOperation op = mQueue.poll();
+
+        mCurrentOperation = op;
+        op.execute();
+    }
+
+    public void onGattOperationFinished() {
+        mCurrentOperation = null;
+        driveQueue();
     }
 
     @Override
@@ -225,11 +241,9 @@ public class FlutterBluePlugin implements MethodCallHandler {
                     result.error("discover_services_error", "no instance of BluetoothGatt, have you connected first?", null);
                     return;
                 }
-                if(gattServer.discoverServices()) {
-                    result.success(null);
-                } else {
-                    result.error("discover_services_error", "unknown reason", null);
-                }
+
+                queueOperation(new DiscoverServicesOperation(gattServer, result, this));
+
                 break;
             }
 
@@ -275,11 +289,7 @@ public class FlutterBluePlugin implements MethodCallHandler {
                     return;
                 }
 
-                if(gattServer.readCharacteristic(characteristic)) {
-                    result.success(null);
-                } else {
-                    result.error("read_characteristic_error", "unknown reason, may occur if readCharacteristic was called before last read finished.", null);
-                }
+                queueOperation(new ReadCharacteristicOperation(gattServer, characteristic, result, this));
                 break;
             }
 
@@ -306,11 +316,7 @@ public class FlutterBluePlugin implements MethodCallHandler {
                     return;
                 }
 
-                if(gattServer.readDescriptor(descriptor)) {
-                    result.success(null);
-                } else {
-                    result.error("read_descriptor_error", "unknown reason, may occur if readDescriptor was called before last read finished.", null);
-                }
+                queueOperation(new ReadDescriptorOperation(gattServer, descriptor, result, this));
                 break;
             }
 
@@ -347,12 +353,7 @@ public class FlutterBluePlugin implements MethodCallHandler {
                     characteristic.setWriteType(BluetoothGattCharacteristic.WRITE_TYPE_DEFAULT);
                 }
 
-                if(!gattServer.writeCharacteristic(characteristic)){
-                    result.error("write_characteristic_error", "writeCharacteristic failed", null);
-                    return;
-                }
-
-                result.success(null);
+                queueOperation(new WriteCharacteristicOperation(gattServer, characteristic, result, this));
                 break;
             }
 
@@ -384,12 +385,7 @@ public class FlutterBluePlugin implements MethodCallHandler {
                     result.error("write_descriptor_error", "could not set the local value for descriptor", null);
                 }
 
-                if(!gattServer.writeDescriptor(descriptor)){
-                    result.error("write_descriptor_error", "writeCharacteristic failed", null);
-                    return;
-                }
-
-                result.success(null);
+                queueOperation(new WriteDescriptorOperation(gattServer, descriptor, result, this));
                 break;
             }
 
@@ -410,51 +406,12 @@ public class FlutterBluePlugin implements MethodCallHandler {
                 try {
                     gattServer = locateGatt(request.getRemoteId());
                     characteristic = locateCharacteristic(gattServer, request.getServiceUuid(), request.getSecondaryServiceUuid(), request.getCharacteristicUuid());
-                    cccDescriptor = characteristic.getDescriptor(CCCD_ID);
-                    if(cccDescriptor == null) {
-                        throw new Exception("could not locate CCCD descriptor for characteristic: " +characteristic.getUuid().toString());
-                    }
                 } catch(Exception e) {
                     result.error("set_notification_error", e.getMessage(), null);
                     return;
                 }
 
-                byte[] value = null;
-
-                if(request.getEnable()) {
-                    boolean canNotify = (characteristic.getProperties() & BluetoothGattCharacteristic.PROPERTY_NOTIFY) > 0;
-                    boolean canIndicate = (characteristic.getProperties() & BluetoothGattCharacteristic.PROPERTY_INDICATE) > 0;
-                    if(!canIndicate && !canNotify) {
-                        result.error("set_notification_error", "the characteristic cannot notify or indicate", null);
-                        return;
-                    }
-                    if(canIndicate) {
-                        value = BluetoothGattDescriptor.ENABLE_INDICATION_VALUE;
-                    }
-                    if(canNotify) {
-                        value = BluetoothGattDescriptor.ENABLE_NOTIFICATION_VALUE;
-                    }
-                } else {
-                    value = BluetoothGattDescriptor.DISABLE_NOTIFICATION_VALUE;
-                }
-
-
-                if(!cccDescriptor.setValue(value)) {
-                    result.error("set_notification_error", "error when setting the descriptor value to: " + value, null);
-                    return;
-                }
-
-                if(!gattServer.writeDescriptor(cccDescriptor)) {
-                    result.error("set_notification_error", "error when writing the descriptor", null);
-                    return;
-                }
-
-                if(!gattServer.setCharacteristicNotification(characteristic, request.getEnable())){
-                    result.error("set_notification_error", "could not set characteristic notifications to :" + request.getEnable(), null);
-                    return;
-                }
-
-                result.success(ProtoMaker.from(characteristic, gattServer).toByteArray());
+                queueOperation(new SetNotificationOperation(gattServer, characteristic, request.getEnable(), result, this));
                 break;
             }
 
@@ -645,58 +602,6 @@ public class FlutterBluePlugin implements MethodCallHandler {
         }
     };
 
-    private EventSink servicesDiscoveredSink;
-    private final StreamHandler servicesDiscoveredHandler = new StreamHandler() {
-        @Override
-        public void onListen(Object o, EventChannel.EventSink eventSink) {
-            servicesDiscoveredSink = eventSink;
-        }
-
-        @Override
-        public void onCancel(Object o) {
-            servicesDiscoveredSink = null;
-        }
-    };
-
-    private EventSink characteristicReadSink;
-    private final StreamHandler characteristicReadHandler = new StreamHandler() {
-        @Override
-        public void onListen(Object o, EventChannel.EventSink eventSink) {
-            characteristicReadSink = eventSink;
-        }
-
-        @Override
-        public void onCancel(Object o) {
-            characteristicReadSink = null;
-        }
-    };
-
-    private EventSink descriptorReadSink;
-    private final StreamHandler descriptorReadHandler = new StreamHandler() {
-        @Override
-        public void onListen(Object o, EventChannel.EventSink eventSink) {
-            descriptorReadSink = eventSink;
-        }
-
-        @Override
-        public void onCancel(Object o) {
-            descriptorReadSink = null;
-        }
-    };
-
-    private EventSink characteristicNotifiedSink;
-    private final StreamHandler characteristicNotifiedHandler = new StreamHandler() {
-        @Override
-        public void onListen(Object o, EventChannel.EventSink eventSink) {
-            characteristicNotifiedSink = eventSink;
-        }
-
-        @Override
-        public void onCancel(Object o) {
-            characteristicNotifiedSink = null;
-        }
-    };
-
     private final BluetoothGattCallback mGattCallback = new BluetoothGattCallback() {
         @Override
         public void onConnectionStateChange(BluetoothGatt gatt, int status, int newState) {
@@ -706,95 +611,40 @@ public class FlutterBluePlugin implements MethodCallHandler {
 
         @Override
         public void onServicesDiscovered(BluetoothGatt gatt, int status) {
-            Log.d(TAG, "onServicesDiscovered: " + gatt.getServices().size() + " sink:" + servicesDiscoveredSink);
-            if(servicesDiscoveredSink != null) {
-                Protos.DiscoverServicesResult.Builder p = Protos.DiscoverServicesResult.newBuilder();
-                p.setRemoteId(gatt.getDevice().getAddress());
-                for(BluetoothGattService s : gatt.getServices()) {
-                    p.addServices(ProtoMaker.from(gatt.getDevice(), s, gatt));
-                }
-                servicesDiscoveredSink.success(p.build().toByteArray());
-            }
+            if (mCurrentOperation!=null) mCurrentOperation.onServicesDiscovered(gatt, status);
+            else Log.w(TAG, "onServicesDiscovered, but no operation in progress");
         }
 
         @Override
         public void onCharacteristicRead(BluetoothGatt gatt, BluetoothGattCharacteristic characteristic, int status) {
-            Log.d(TAG, "onCharacteristicRead: ");
-            if(characteristicReadSink != null) {
-                Protos.ReadCharacteristicResponse.Builder p = Protos.ReadCharacteristicResponse.newBuilder();
-                p.setRemoteId(gatt.getDevice().getAddress());
-                p.setCharacteristic(ProtoMaker.from(characteristic, gatt));
-                characteristicReadSink.success(p.build().toByteArray());
-            }
+            if (mCurrentOperation!=null) mCurrentOperation.onCharacteristicRead(gatt, characteristic, status);
+            else Log.w(TAG, "onCharacteristicRead, but no operation in progress");
         }
 
         @Override
         public void onCharacteristicWrite(BluetoothGatt gatt, BluetoothGattCharacteristic characteristic, int status) {
-            Log.d(TAG, "onCharacteristicWrite: ");
-            Protos.WriteCharacteristicRequest.Builder request = Protos.WriteCharacteristicRequest.newBuilder();
-            request.setRemoteId(gatt.getDevice().getAddress());
-            request.setCharacteristicUuid(characteristic.getUuid().toString());
-            request.setServiceUuid(characteristic.getService().getUuid().toString());
-            Protos.WriteCharacteristicResponse.Builder p = Protos.WriteCharacteristicResponse.newBuilder();
-            p.setRequest(request);
-            p.setSuccess(status == BluetoothGatt.GATT_SUCCESS);
-            channel.invokeMethod("WriteCharacteristicResponse", p.build().toByteArray());
+            if (mCurrentOperation!=null) mCurrentOperation.onCharacteristicWrite(gatt, characteristic, status);
+            else Log.w(TAG, "onCharacteristicWrite, but no operation in progress");
         }
 
         @Override
         public void onCharacteristicChanged(BluetoothGatt gatt, BluetoothGattCharacteristic characteristic) {
-            Log.d(TAG, "onCharacteristicChanged: " + characteristic.getValue());
-            if(characteristicNotifiedSink != null) {
-                // Rebuild the ReadAttributeRequest and send back along with response
-                Protos.OnNotificationResponse.Builder q = Protos.OnNotificationResponse.newBuilder();
-                q.setRemoteId(gatt.getDevice().getAddress());
-                q.setCharacteristic(ProtoMaker.from(characteristic, gatt));
-                characteristicNotifiedSink.success(q.build().toByteArray());
-            }
+            Protos.OnNotificationResponse.Builder q = Protos.OnNotificationResponse.newBuilder();
+            q.setRemoteId(gatt.getDevice().getAddress());
+            q.setCharacteristic(ProtoMaker.from(characteristic, gatt));
+            channel.invokeMethod("CharacteristicChanged", q.build().toByteArray());
         }
 
         @Override
         public void onDescriptorRead(BluetoothGatt gatt, BluetoothGattDescriptor descriptor, int status) {
-            Log.d(TAG, "onDescriptorRead: ");
-            if(descriptorReadSink != null) {
-                // Rebuild the ReadAttributeRequest and send back along with response
-                Protos.ReadDescriptorRequest.Builder q = Protos.ReadDescriptorRequest.newBuilder();
-                q.setRemoteId(gatt.getDevice().getAddress());
-                q.setCharacteristicUuid(descriptor.getCharacteristic().getUuid().toString());
-                q.setDescriptorUuid(descriptor.getUuid().toString());
-                if(descriptor.getCharacteristic().getService().getType() == BluetoothGattService.SERVICE_TYPE_PRIMARY) {
-                    q.setServiceUuid(descriptor.getCharacteristic().getService().getUuid().toString());
-                } else {
-                    // Reverse search to find service
-                    for(BluetoothGattService s : gatt.getServices()) {
-                        for(BluetoothGattService ss : s.getIncludedServices()) {
-                            if(ss.getUuid().equals(descriptor.getCharacteristic().getService().getUuid())){
-                                q.setServiceUuid(s.getUuid().toString());
-                                q.setSecondaryServiceUuid(ss.getUuid().toString());
-                                break;
-                            }
-                        }
-                    }
-                }
-                Protos.ReadDescriptorResponse.Builder p = Protos.ReadDescriptorResponse.newBuilder();
-                p.setRequest(q);
-                p.setValue(ByteString.copyFrom(descriptor.getValue()));
-                descriptorReadSink.success(p.build().toByteArray());
-            }
+            if (mCurrentOperation!=null) mCurrentOperation.onDescriptorRead(gatt, descriptor, status);
+            else Log.w(TAG, "onDescriptorRead, but no operation in progress");
         }
 
         @Override
         public void onDescriptorWrite(BluetoothGatt gatt, BluetoothGattDescriptor descriptor, int status) {
-            Log.d(TAG, "onDescriptorWrite: ");
-            Protos.WriteDescriptorRequest.Builder request = Protos.WriteDescriptorRequest.newBuilder();
-            request.setRemoteId(gatt.getDevice().getAddress());
-            request.setDescriptorUuid(descriptor.getUuid().toString());
-            request.setCharacteristicUuid(descriptor.getCharacteristic().getUuid().toString());
-            request.setServiceUuid(descriptor.getCharacteristic().getService().getUuid().toString());
-            Protos.WriteDescriptorResponse.Builder p = Protos.WriteDescriptorResponse.newBuilder();
-            p.setRequest(request);
-            p.setSuccess(status == BluetoothGatt.GATT_SUCCESS);
-            channel.invokeMethod("WriteDescriptorResponse", p.build().toByteArray());
+            if (mCurrentOperation!=null) mCurrentOperation.onDescriptorWrite(gatt, descriptor, status);
+            else Log.w(TAG, "onDescriptorWrite, but no operation in progress");
         }
 
         @Override

--- a/android/src/main/java/com/pauldemarco/flutterblue/GattOperation.java
+++ b/android/src/main/java/com/pauldemarco/flutterblue/GattOperation.java
@@ -1,0 +1,86 @@
+// Copyright 2018, Daniel Turing.
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+package com.pauldemarco.flutterblue;
+
+import android.bluetooth.BluetoothGatt;
+import android.bluetooth.BluetoothGattCallback;
+import android.bluetooth.BluetoothGattCharacteristic;
+import android.bluetooth.BluetoothGattDescriptor;
+
+import io.flutter.plugin.common.MethodChannel.Result;
+
+
+// TODO: timeout.
+public abstract class GattOperation extends BluetoothGattCallback {
+    protected BluetoothGatt mGattServer;
+    protected Result mResult;
+    protected FinishedCallback mFinishedCallback;
+
+    public interface FinishedCallback {
+        void onGattOperationFinished();
+    }
+
+    public GattOperation(BluetoothGatt g, Result r, FinishedCallback f) {
+        mGattServer = g;
+        mResult = r;
+        mFinishedCallback = f;
+    }
+
+    public abstract void execute();
+
+    public void finished() {
+        if (mFinishedCallback!=null) mFinishedCallback.onGattOperationFinished();
+    }
+
+    @Override
+    public void onConnectionStateChange(BluetoothGatt gatt, int status, int newState) {
+        mResult.error("invalid_reply", "unexpected onConnectionStateChange", null);
+    }
+
+    @Override
+    public void onServicesDiscovered(BluetoothGatt gatt, int status) {
+        mResult.error("invalid_reply", "unexpected onServicesDiscovered", null);
+    }
+
+    @Override
+    public void onCharacteristicRead(BluetoothGatt gatt, BluetoothGattCharacteristic characteristic, int status) {
+        mResult.error("invalid_reply", "unexpected onCharacteristicRead", null);
+    }
+
+    @Override
+    public void onCharacteristicWrite(BluetoothGatt gatt, BluetoothGattCharacteristic characteristic, int status) {
+        mResult.error("invalid_reply", "unexpected onCharacteristicWrite", null);
+    }
+
+    @Override
+    public void onCharacteristicChanged(BluetoothGatt gatt, BluetoothGattCharacteristic characteristic) {
+        mResult.error("invalid_reply", "unexpected onCharacteristicChanged", null);
+    }
+
+    @Override
+    public void onDescriptorRead(BluetoothGatt gatt, BluetoothGattDescriptor descriptor, int status) {
+        mResult.error("invalid_reply", "unexpected onDescriptorRead", null);
+    }
+
+    @Override
+    public void onDescriptorWrite(BluetoothGatt gatt, BluetoothGattDescriptor descriptor, int status) {
+        mResult.error("invalid_reply", "unexpected onDescriptorWrite", null);
+    }
+
+    @Override
+    public void onReliableWriteCompleted(BluetoothGatt gatt, int status) {
+        mResult.error("invalid_reply", "unexpected onReliableWriteCompleted", null);
+    }
+
+    @Override
+    public void onReadRemoteRssi(BluetoothGatt gatt, int rssi, int status) {
+        mResult.error("invalid_reply", "unexpected onReadRemoteRssi", null);
+    }
+
+    @Override
+    public void onMtuChanged(BluetoothGatt gatt, int mtu, int status) {
+        mResult.error("invalid_reply", "unexpected onMtuChanged", null);
+    }
+}

--- a/android/src/main/java/com/pauldemarco/flutterblue/ReadCharacteristicOperation.java
+++ b/android/src/main/java/com/pauldemarco/flutterblue/ReadCharacteristicOperation.java
@@ -1,0 +1,36 @@
+// Copyright 2018, Daniel Turing.
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+package com.pauldemarco.flutterblue;
+
+import android.bluetooth.BluetoothGatt;
+import android.bluetooth.BluetoothGattCharacteristic;
+import io.flutter.plugin.common.MethodChannel.Result;
+
+public class ReadCharacteristicOperation extends GattOperation {
+
+    private BluetoothGattCharacteristic characteristic;
+
+    public ReadCharacteristicOperation(BluetoothGatt g, BluetoothGattCharacteristic c, Result r, GattOperation.FinishedCallback f) {
+        super(g,r,f);
+        characteristic = c;
+    }
+
+    public void execute() {
+        if(!mGattServer.readCharacteristic(characteristic)) {
+            mResult.error("read_characteristic_error", "Could not initiate request to read characteristic value.", null);
+            finished();
+        }
+    }
+
+    @Override
+    public void onCharacteristicRead(BluetoothGatt gatt, BluetoothGattCharacteristic characteristic, int status) {
+        Protos.ReadCharacteristicResponse.Builder p = Protos.ReadCharacteristicResponse.newBuilder();
+        p.setRemoteId(mGattServer.getDevice().getAddress());
+        p.setCharacteristic(ProtoMaker.from(characteristic, mGattServer));
+        mResult.success(p.build().toByteArray());
+
+        finished();
+    }
+}

--- a/android/src/main/java/com/pauldemarco/flutterblue/ReadDescriptorOperation.java
+++ b/android/src/main/java/com/pauldemarco/flutterblue/ReadDescriptorOperation.java
@@ -1,0 +1,58 @@
+// Copyright 2018, Daniel Turing.
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+package com.pauldemarco.flutterblue;
+
+import android.bluetooth.BluetoothGatt;
+import android.bluetooth.BluetoothGattService;
+import android.bluetooth.BluetoothGattDescriptor;
+import io.flutter.plugin.common.MethodChannel.Result;
+import com.google.protobuf.ByteString;
+
+public class ReadDescriptorOperation extends GattOperation {
+
+    private BluetoothGattDescriptor descriptor;
+
+    public ReadDescriptorOperation(BluetoothGatt g, BluetoothGattDescriptor d, Result r, GattOperation.FinishedCallback f) {
+        super(g,r,f);
+        descriptor = d;
+    }
+
+    public void execute() {
+        if(!mGattServer.readDescriptor(descriptor)) {
+            mResult.error("read_descriptor_error", "unknown reason, may occur if readDescriptor was called before last read finished.", null);
+            finished();
+        }
+    }
+
+    @Override
+    public void onDescriptorRead(BluetoothGatt gatt, BluetoothGattDescriptor descriptor, int status) {
+        // Rebuild the ReadAttributeRequest and send back along with response
+        Protos.ReadDescriptorRequest.Builder q = Protos.ReadDescriptorRequest.newBuilder();
+        q.setRemoteId(gatt.getDevice().getAddress());
+        q.setCharacteristicUuid(descriptor.getCharacteristic().getUuid().toString());
+        q.setDescriptorUuid(descriptor.getUuid().toString());
+        if(descriptor.getCharacteristic().getService().getType() == BluetoothGattService.SERVICE_TYPE_PRIMARY) {
+            q.setServiceUuid(descriptor.getCharacteristic().getService().getUuid().toString());
+        } else {
+            // Reverse search to find service
+            for(BluetoothGattService s : gatt.getServices()) {
+                for(BluetoothGattService ss : s.getIncludedServices()) {
+                    if(ss.getUuid().equals(descriptor.getCharacteristic().getService().getUuid())){
+                        q.setServiceUuid(s.getUuid().toString());
+                        q.setSecondaryServiceUuid(ss.getUuid().toString());
+                        break;
+                    }
+                }
+            }
+        }
+
+        Protos.ReadDescriptorResponse.Builder p = Protos.ReadDescriptorResponse.newBuilder();
+        p.setRequest(q);
+        p.setValue(ByteString.copyFrom(descriptor.getValue()));
+        mResult.success(p.build().toByteArray());
+
+        finished();
+    }
+}

--- a/android/src/main/java/com/pauldemarco/flutterblue/SetNotificationOperation.java
+++ b/android/src/main/java/com/pauldemarco/flutterblue/SetNotificationOperation.java
@@ -1,0 +1,84 @@
+// Copyright 2018, Daniel Turing.
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+package com.pauldemarco.flutterblue;
+
+import android.bluetooth.BluetoothGatt;
+import android.bluetooth.BluetoothGattCharacteristic;
+import android.bluetooth.BluetoothGattDescriptor;
+import io.flutter.plugin.common.MethodChannel.Result;
+
+import java.util.UUID;
+
+public class SetNotificationOperation extends GattOperation {
+    static final private UUID CCCD_ID = UUID.fromString("000002902-0000-1000-8000-00805f9b34fb");
+
+    private BluetoothGattCharacteristic characteristic;
+    private boolean enable;
+
+    public SetNotificationOperation(BluetoothGatt g, BluetoothGattCharacteristic c, boolean e, Result r, GattOperation.FinishedCallback f) {
+        super(g,r,f);
+        characteristic = c;
+        enable = e;
+    }
+
+    public void execute() {
+        BluetoothGattDescriptor cccDescriptor;
+        try {
+            cccDescriptor = characteristic.getDescriptor(CCCD_ID);
+            if(cccDescriptor == null) {
+                throw new Exception("could not locate CCCD descriptor for characteristic: " +characteristic.getUuid().toString());
+            }
+        } catch(Exception e) {
+            mResult.error("set_notification_error", e.getMessage(), null);
+            finished();
+            return;
+        }
+
+        byte[] value = null;
+
+        if(enable) {
+            boolean canNotify = (characteristic.getProperties() & BluetoothGattCharacteristic.PROPERTY_NOTIFY) > 0;
+            boolean canIndicate = (characteristic.getProperties() & BluetoothGattCharacteristic.PROPERTY_INDICATE) > 0;
+            if(!canIndicate && !canNotify) {
+                mResult.error("set_notification_error", "the characteristic cannot notify or indicate", null);
+                finished();
+                return;
+            }
+            if(canIndicate) {
+                value = BluetoothGattDescriptor.ENABLE_INDICATION_VALUE;
+            }
+            if(canNotify) {
+                value = BluetoothGattDescriptor.ENABLE_NOTIFICATION_VALUE;
+            }
+        } else {
+            value = BluetoothGattDescriptor.DISABLE_NOTIFICATION_VALUE;
+        }
+
+
+        if(!cccDescriptor.setValue(value)) {
+            mResult.error("set_notification_error", "error when setting the descriptor value to: " + value, null);
+            finished();
+            return;
+        }
+
+        if(!mGattServer.setCharacteristicNotification(characteristic, enable)){
+            mResult.error("set_notification_error", "could not set characteristic notifications to :" + enable, null);
+            finished();
+            return;
+        }
+
+        if(!mGattServer.writeDescriptor(cccDescriptor)) {
+            mResult.error("set_notification_error", "error when writing the descriptor", null);
+            finished();
+            return;
+        }
+    }
+
+    @Override
+    public void onDescriptorWrite(BluetoothGatt gatt, BluetoothGattDescriptor descriptor, int status) {
+        mResult.success(ProtoMaker.from(characteristic, mGattServer).toByteArray());
+        finished();
+    }
+}

--- a/android/src/main/java/com/pauldemarco/flutterblue/WriteCharacteristicOperation.java
+++ b/android/src/main/java/com/pauldemarco/flutterblue/WriteCharacteristicOperation.java
@@ -1,0 +1,49 @@
+// Copyright 2018, Daniel Turing.
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+package com.pauldemarco.flutterblue;
+
+import android.bluetooth.BluetoothGatt;
+import android.bluetooth.BluetoothGattCharacteristic;
+import io.flutter.plugin.common.MethodChannel.Result;
+
+public class WriteCharacteristicOperation extends GattOperation {
+
+    private BluetoothGattCharacteristic characteristic;
+
+    public WriteCharacteristicOperation(BluetoothGatt g, BluetoothGattCharacteristic c, Result r, GattOperation.FinishedCallback f) {
+        super(g,r,f);
+        characteristic = c;
+    }
+
+    public void execute() {
+        if(!mGattServer.writeCharacteristic(characteristic)){
+            mResult.error("write_characteristic_error", "Could not initiate request to wrtie characteristic value.", null);
+            finished();
+        }
+
+        if(characteristic.getWriteType() == BluetoothGattCharacteristic.WRITE_TYPE_NO_RESPONSE) {
+            finished();
+        }
+    }
+
+    @Override
+    public void onCharacteristicWrite(BluetoothGatt gatt, BluetoothGattCharacteristic characteristic, int status) {
+        if(characteristic.getWriteType() == BluetoothGattCharacteristic.WRITE_TYPE_NO_RESPONSE) {
+            return;
+        }
+
+        Protos.WriteCharacteristicRequest.Builder request = Protos.WriteCharacteristicRequest.newBuilder();
+        request.setRemoteId(gatt.getDevice().getAddress());
+        request.setCharacteristicUuid(characteristic.getUuid().toString());
+        request.setServiceUuid(characteristic.getService().getUuid().toString());
+        Protos.WriteCharacteristicResponse.Builder p = Protos.WriteCharacteristicResponse.newBuilder();
+        p.setRequest(request);
+        p.setSuccess(status == BluetoothGatt.GATT_SUCCESS);
+
+        mResult.success(p.build().toByteArray());
+
+        finished();
+    }
+}

--- a/android/src/main/java/com/pauldemarco/flutterblue/WriteCharacteristicOperation.java
+++ b/android/src/main/java/com/pauldemarco/flutterblue/WriteCharacteristicOperation.java
@@ -22,18 +22,10 @@ public class WriteCharacteristicOperation extends GattOperation {
             mResult.error("write_characteristic_error", "Could not initiate request to wrtie characteristic value.", null);
             finished();
         }
-
-        if(characteristic.getWriteType() == BluetoothGattCharacteristic.WRITE_TYPE_NO_RESPONSE) {
-            finished();
-        }
     }
 
     @Override
     public void onCharacteristicWrite(BluetoothGatt gatt, BluetoothGattCharacteristic characteristic, int status) {
-        if(characteristic.getWriteType() == BluetoothGattCharacteristic.WRITE_TYPE_NO_RESPONSE) {
-            return;
-        }
-
         Protos.WriteCharacteristicRequest.Builder request = Protos.WriteCharacteristicRequest.newBuilder();
         request.setRemoteId(gatt.getDevice().getAddress());
         request.setCharacteristicUuid(characteristic.getUuid().toString());

--- a/android/src/main/java/com/pauldemarco/flutterblue/WriteDescriptorOperation.java
+++ b/android/src/main/java/com/pauldemarco/flutterblue/WriteDescriptorOperation.java
@@ -1,0 +1,43 @@
+// Copyright 2018, Daniel Turing.
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+package com.pauldemarco.flutterblue;
+
+import android.bluetooth.BluetoothGatt;
+import android.bluetooth.BluetoothGattService;
+import android.bluetooth.BluetoothGattDescriptor;
+import io.flutter.plugin.common.MethodChannel.Result;
+import com.google.protobuf.ByteString;
+
+public class WriteDescriptorOperation extends GattOperation {
+
+    private BluetoothGattDescriptor descriptor;
+
+    public WriteDescriptorOperation(BluetoothGatt g, BluetoothGattDescriptor d, Result r, GattOperation.FinishedCallback f) {
+        super(g,r,f);
+        descriptor = d;
+    }
+
+    public void execute() {
+        if(!mGattServer.writeDescriptor(descriptor)){
+            mResult.error("write_descriptor_error", "writeCharacteristic failed", null);
+            return;
+        }
+    }
+
+    @Override
+    public void onDescriptorWrite(BluetoothGatt gatt, BluetoothGattDescriptor descriptor, int status) {
+        Protos.WriteDescriptorRequest.Builder request = Protos.WriteDescriptorRequest.newBuilder();
+        request.setRemoteId(gatt.getDevice().getAddress());
+        request.setDescriptorUuid(descriptor.getUuid().toString());
+        request.setCharacteristicUuid(descriptor.getCharacteristic().getUuid().toString());
+        request.setServiceUuid(descriptor.getCharacteristic().getService().getUuid().toString());
+        Protos.WriteDescriptorResponse.Builder p = Protos.WriteDescriptorResponse.newBuilder();
+        p.setRequest(request);
+        p.setSuccess(status == BluetoothGatt.GATT_SUCCESS);
+        mResult.success(p.build().toByteArray());
+
+        finished();
+    }
+}

--- a/lib/src/flutter_blue.dart
+++ b/lib/src/flutter_blue.dart
@@ -9,14 +9,6 @@ class FlutterBlue {
   final EventChannel _stateChannel = const EventChannel('$NAMESPACE/state');
   final EventChannel _scanResultChannel =
       const EventChannel('$NAMESPACE/scanResult');
-  final EventChannel _servicesDiscoveredChannel =
-      const EventChannel('$NAMESPACE/servicesDiscovered');
-  final EventChannel _characteristicReadChannel =
-      const EventChannel('$NAMESPACE/characteristicRead');
-  final EventChannel _descriptorReadChannel =
-      const EventChannel('$NAMESPACE/descriptorRead');
-  final EventChannel _characteristicNotifiedChannel =
-      const EventChannel('$NAMESPACE/characteristicNotified');
   final StreamController<MethodCall> _methodStreamController =
       new StreamController.broadcast(); // ignore: close_sinks
   Stream<MethodCall> get _methodStream => _methodStreamController


### PR DESCRIPTION
Bluetooth GATT operations cannot run concurrently, so they must be queued up to let old operations
finish before a new one is triggered.

Also, there is no need for a separate EventChannel for every kind of operation; answers (except for
scanning) are now sent via the plugin's main MethodChannel.

this mostly does #11, and fixes #30