### PR TITLE
Fix application crash when erroneous advertisements are received.

### DIFF
--- a/android/src/main/java/com/pauldemarco/flutterblue/ProtoMaker.java
+++ b/android/src/main/java/com/pauldemarco/flutterblue/ProtoMaker.java
@@ -13,6 +13,8 @@ import android.bluetooth.BluetoothProfile;
 
 import com.google.protobuf.ByteString;
 
+import java.nio.BufferUnderflowException;
+
 import java.util.UUID;
 
 /**
@@ -26,8 +28,17 @@ public class ProtoMaker {
     static Protos.ScanResult from(BluetoothDevice device, byte[] advertisementData, int rssi) {
         Protos.ScanResult.Builder p = Protos.ScanResult.newBuilder();
         p.setDevice(from(device));
-        if(advertisementData != null && advertisementData.length > 0)
-            p.setAdvertisementData(AdvertisementParser.parse(advertisementData));
+        if(advertisementData != null && advertisementData.length > 0) {
+            try {
+                p.setAdvertisementData(AdvertisementParser.parse(advertisementData));
+            } catch (ArrayIndexOutOfBoundsException e) {
+                // Should handle exception gracefully
+            } catch (BufferUnderflowException e) {
+                // Should handle exception gracefully
+            } catch (RuntimeException e) {
+                // Should handle error parsing local name
+            }
+        }
         p.setRssi(rssi);
         return p.build();
     }

--- a/android/src/main/java/com/pauldemarco/flutterblue/ProtoMaker.java
+++ b/android/src/main/java/com/pauldemarco/flutterblue/ProtoMaker.java
@@ -35,11 +35,8 @@ public class ProtoMaker {
                 // Should handle exception gracefully
             } catch (BufferUnderflowException e) {
                 // Should handle exception gracefully
-<<<<<<< HEAD
             } catch (RuntimeException e) {
                 // Should handle error parsing local name
-=======
->>>>>>> 1972fc2b3cd1231e71c1ff7b1a1383e97f8f4c27
             }
         }
         p.setRssi(rssi);


### PR DESCRIPTION
The application will crash if erroneous advertisements are received or the device name is not properly encoded. I don't know how these should be handled (if they even need to be), but they can at least be caught to prevent the application from crashing.