### PR TITLE
Return early when the advertisement data is empty.

### DIFF
--- a/android/src/main/java/com/pauldemarco/flutterblue/AdvertisementParser.java
+++ b/android/src/main/java/com/pauldemarco/flutterblue/AdvertisementParser.java
@@ -48,8 +48,13 @@ class AdvertisementParser {
    * @throws ArrayIndexOutOfBoundsException if the input is truncated.
    */
   static AdvertisementData parse(byte[] rawData) {
-    ByteBuffer data = ByteBuffer.wrap(rawData).asReadOnlyBuffer().order(ByteOrder.LITTLE_ENDIAN);
     AdvertisementData.Builder ret = AdvertisementData.newBuilder();
+    if (rawData.length == 0) {
+      return ret.build();
+    }
+
+    ByteBuffer data = ByteBuffer.wrap(rawData).asReadOnlyBuffer().order(ByteOrder.LITTLE_ENDIAN);
+
     boolean seenLongLocalName = false;
     do {
       int length = data.get() & 0xFF;


### PR DESCRIPTION
This PR should help with #71.
I will get to see more details coming week (when testing with a device that could trigger the issue consistently).

However, the BufferUnderFlowException does point to a empty byte array and should be avoided.