### PR TITLE
Remove strict type from isAvaliable

### DIFF
--- a/lib/src/flutter_blue.dart
+++ b/lib/src/flutter_blue.dart
@@ -30,7 +30,7 @@ class FlutterBlue {
   static FlutterBlue get instance => _instance;
 
   /// Checks whether the device supports Bluetooth
-  Future<bool> get isAvailable => _channel.invokeMethod('isAvailable');
+  Future<dynamic> get isAvailable => _channel.invokeMethod('isAvailable');
 
   /// Checks if Bluetooth functionality is turned on
   Future<bool> get isOn => _channel.invokeMethod('isOn');


### PR DESCRIPTION
- At the moment gives Future<dynamic> is not Future<bool> exception
- isAvaliable is needed to prevent an error when running in an emulator and there is no bluetooth

Should probably be fixed properly somewhere else but this will at least make it usable