### PR TITLE
Cleanup resources when activity has been destroyed

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -8,8 +8,8 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.3'
-        classpath 'com.google.protobuf:protobuf-gradle-plugin:0.8.3'
+        classpath 'com.android.tools.build:gradle:3.2.0'
+        classpath 'com.google.protobuf:protobuf-gradle-plugin:0.8.6'
     }
 }
 

--- a/android/src/main/java/com/pauldemarco/flutterblue/AdvertisementParser.java
+++ b/android/src/main/java/com/pauldemarco/flutterblue/AdvertisementParser.java
@@ -130,7 +130,7 @@ class AdvertisementParser {
           break;
         }
       }
-    } while (true);
+    } while (data.hasRemaining());
     return ret.build();
   }
 }

--- a/android/src/main/java/com/pauldemarco/flutterblue/FlutterBluePlugin.java
+++ b/android/src/main/java/com/pauldemarco/flutterblue/FlutterBluePlugin.java
@@ -676,13 +676,23 @@ public class FlutterBluePlugin implements MethodCallHandler, RequestPermissionsR
     }
 
     private BluetoothAdapter.LeScanCallback scanCallback18;
-
+    private final static char[] hexArray = "0123456789ABCDEF".toCharArray();
+    public static String bytesToHex(byte[] bytes) {
+        char[] hexChars = new char[bytes.length * 2];
+        for ( int j = 0; j < bytes.length; j++ ) {
+            int v = bytes[j] & 0xFF;
+            hexChars[j * 2] = hexArray[v >>> 4];
+            hexChars[j * 2 + 1] = hexArray[v & 0x0F];
+        }
+        return new String(hexChars);
+    }
     private BluetoothAdapter.LeScanCallback getScanCallback18() {
         if(scanCallback18 == null) {
             scanCallback18 = new BluetoothAdapter.LeScanCallback() {
                 @Override
                 public void onLeScan(final BluetoothDevice bluetoothDevice, int rssi,
                                      byte[] scanRecord) {
+                    Log.d(TAG, "scanResultsSink: " + scanResultsSink + ", discovered: "+ bluetoothDevice + ", rssi: " + rssi + ", scanRecord: " + bytesToHex(scanRecord));
                     if(scanResultsSink != null) {
                         Protos.ScanResult scanResult = ProtoMaker.from(bluetoothDevice, scanRecord, rssi);
                         scanResultsSink.success(scanResult.toByteArray());

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -6,8 +6,8 @@ dependencies:
     sdk: flutter
   flutter_blue:
     path: ../
-  intl: '^0.15.1'
-  intl_translation: '^0.15.0'
+  intl: any
+  intl_translation: any
 
 # For information on the generic Dart part of this file, see the
 # following page: https://www.dartlang.org/tools/pub/pubspec

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,5 +20,5 @@ dev_dependencies:
     sdk: flutter
 
 environment:
-  sdk: '>=2.0.0-dev.28.0 <3.0.0'
-  flutter: '>=0.2.4 <2.0.0'
+  sdk: '>=2.0.0 <3.0.0'
+


### PR DESCRIPTION
This was tested out on phones with the "Don't keep Activities" developer option activated. In that case, the activity really gets destroyed.

While this fixes the immediate leaks, the better solution may be to keep the connections in the background and attach them to the next, new, activity once it has been started.