### PR TITLE
Compatibility with latest Android Studio and Gradle plugin

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -9,7 +9,7 @@ buildscript {
 
     dependencies {
         classpath 'com.android.tools.build:gradle:3.1.3'
-        classpath 'com.google.protobuf:protobuf-gradle-plugin:0.8.3'
+        classpath 'com.google.protobuf:protobuf-gradle-plugin:0.8.6'
     }
 }
 


### PR DESCRIPTION
Hi,

Android Studio 3.2 and Android Gradle Plugin 3.2.0 requires protobuf-gradle-plugin to be at last at 0.8.6 version.

Cheers,