### PR TITLE
allow overriding autoconnect behavior

### DIFF
--- a/android/src/main/java/com/pauldemarco/flutterblue/FlutterBluePlugin.java
+++ b/android/src/main/java/com/pauldemarco/flutterblue/FlutterBluePlugin.java
@@ -90,7 +90,7 @@ public class FlutterBluePlugin implements MethodCallHandler, RequestPermissionsR
         this.servicesDiscoveredChannel = new EventChannel(registrar.messenger(), NAMESPACE+"/servicesDiscovered");
         this.characteristicReadChannel = new EventChannel(registrar.messenger(), NAMESPACE+"/characteristicRead");
         this.descriptorReadChannel = new EventChannel(registrar.messenger(), NAMESPACE+"/descriptorRead");
-        this.mBluetoothManager = (BluetoothManager) r.activity().getSystemService(Context.BLUETOOTH_SERVICE);
+        this.mBluetoothManager = (BluetoothManager) r.context().getSystemService(Context.BLUETOOTH_SERVICE);
         this.mBluetoothAdapter = mBluetoothManager.getAdapter();
         channel.setMethodCallHandler(this);
         stateChannel.setStreamHandler(stateHandler);

--- a/lib/src/flutter_blue.dart
+++ b/lib/src/flutter_blue.dart
@@ -97,10 +97,10 @@ class FlutterBlue {
   /// Timeout closes the stream after a specified [Duration]
   /// To cancel connection to device, simply cancel() the stream subscription
   Stream<BluetoothDeviceState> connect(BluetoothDevice device,
-      {Duration timeout}) async* {
+      {Duration timeout, bool androidAutoConnect = true}) async* {
     var request = protos.ConnectRequest.create()
       ..remoteId = device.id.toString()
-      ..androidAutoConnect = true;
+      ..androidAutoConnect = androidAutoConnect;
     var connected = false;
     StreamSubscription subscription;
     StreamController controller;


### PR DESCRIPTION
For some reason `androidAutoConnect` got hard-coded to `true`, but causes very long connect delays for us (>30s) which is unacceptable. For backwards compatibility, the default value is still `true`, but can now be overriden.

This solution is still not ideal because now we have to deal with reconnects etc. in the app. Long-term, a better fix would be to abstract all of that away behind a simple API.