### PR TITLE
Fixes problem that caused servicesDiscoveredSink to be null

### DIFF
--- a/lib/src/bluetooth_device.dart
+++ b/lib/src/bluetooth_device.dart
@@ -19,10 +19,7 @@ class BluetoothDevice {
 
   /// Discovers services offered by the remote device as well as their characteristics and descriptors
   Future<List<BluetoothService>> discoverServices() async {
-    await FlutterBlue.instance._channel
-        .invokeMethod('discoverServices', id.toString());
-
-    return await FlutterBlue.instance._servicesDiscoveredChannel
+    var response = FlutterBlue.instance._servicesDiscoveredChannel
         .receiveBroadcastStream()
         .map((buffer) =>
             new protos.DiscoverServicesResult.fromBuffer(buffer))
@@ -30,6 +27,11 @@ class BluetoothDevice {
         .map((p) => p.services)
         .map((s) => s.map((p) => new BluetoothService.fromProto(p)).toList())
         .first;
+
+    await FlutterBlue.instance._channel
+        .invokeMethod('discoverServices', id.toString());
+
+    return await response;
   }
 
   /// Returns a list of Bluetooth GATT services offered by the remote device
@@ -52,10 +54,7 @@ class BluetoothDevice {
 
     print('remoteId: ${id.toString()} characteristicUuid: ${characteristic.uuid.toString()} serviceUuid: ${characteristic.serviceUuid.toString()}');
 
-    await FlutterBlue.instance._channel
-        .invokeMethod('readCharacteristic', request.writeToBuffer());
-
-    return await FlutterBlue.instance._characteristicReadChannel
+    var response = FlutterBlue.instance._characteristicReadChannel
         .receiveBroadcastStream()
         .map((buffer) =>
             new protos.ReadCharacteristicResponse.fromBuffer(buffer))
@@ -66,6 +65,11 @@ class BluetoothDevice {
         .map((p) => p.characteristic.value)
         .first
         .then((d) => characteristic.value = d);
+
+    await FlutterBlue.instance._channel
+        .invokeMethod('readCharacteristic', request.writeToBuffer());
+
+    return await response;
   }
 
   /// Retrieves the value of a specified descriptor
@@ -76,13 +80,10 @@ class BluetoothDevice {
       ..characteristicUuid = descriptor.characteristicUuid.toString()
       ..serviceUuid = descriptor.serviceUuid.toString();
 
-    await FlutterBlue.instance._channel
-        .invokeMethod('readDescriptor', request.writeToBuffer());
-
-    return await FlutterBlue.instance._descriptorReadChannel
+    var response = FlutterBlue.instance._descriptorReadChannel
         .receiveBroadcastStream()
         .map((buffer) =>
-            new protos.ReadDescriptorResponse.fromBuffer(buffer))
+    new protos.ReadDescriptorResponse.fromBuffer(buffer))
         .where((p) =>
             (p.request.remoteId == request.remoteId) &&
             (p.request.descriptorUuid == request.descriptorUuid) &&
@@ -91,6 +92,11 @@ class BluetoothDevice {
         .map((d) => d.value)
         .first
         .then((d) => descriptor.value = d);
+
+    await FlutterBlue.instance._channel
+        .invokeMethod('readDescriptor', request.writeToBuffer());
+
+    return await response;
   }
 
   /// Writes the value of a characteristic.

--- a/lib/src/flutter_blue.dart
+++ b/lib/src/flutter_blue.dart
@@ -30,10 +30,16 @@ class FlutterBlue {
   static FlutterBlue get instance => _instance;
 
   /// Checks whether the device supports Bluetooth
-  Future<bool> get isAvailable => _channel.invokeMethod('isAvailable');
+  Future<bool> get isAvailable async {
+    final bool isAvailable = await _channel.invokeMethod('isAvailable');
+    return isAvailable;
+  }
 
   /// Checks if Bluetooth functionality is turned on
-  Future<bool> get isOn => _channel.invokeMethod('isOn');
+  Future<bool> get isOn async {
+    final bool isOn= await _channel.invokeMethod('isOn');
+    return isOn;
+  }
 
   /// Gets the current state of the Bluetooth module
   Future<BluetoothState> get state {


### PR DESCRIPTION
The original code first invoked the native 'discoverServices' method and only then set up the stream to receive the asynchronous answer.

During test, some situations could be identified where the native side provided immediate response when discoverServices was called (probably because the OS had a cached response for discoverServices).

As the response was immediate, the flutter side did not setup the stream to receive the answer yet (receiveBroadcastStream), and the sink was still null.

The updated code first sets up the stream to receive the response from the native side and only then makes the call to the native method 'discoverService'.

In my proposed change for this issue (0689032), I apply the same fix for the methods 'readCharacteristic' and 'readDescriptor' although I never found prove that a similar issue could evolve there.