### PR TITLE
Option to disable android auto connect

### DIFF
--- a/lib/src/flutter_blue.dart
+++ b/lib/src/flutter_blue.dart
@@ -97,10 +97,10 @@ class FlutterBlue {
   /// Timeout closes the stream after a specified [Duration]
   /// To cancel connection to device, simply cancel() the stream subscription
   Stream<BluetoothDeviceState> connect(BluetoothDevice device,
-      {Duration timeout}) async* {
+      {Duration timeout, bool androidAutoConnect = true}) async* {
     var request = protos.ConnectRequest.create()
       ..remoteId = device.id.toString()
-      ..androidAutoConnect = true;
+      ..androidAutoConnect = androidAutoConnect;
     var connected = false;
     StreamSubscription subscription;
     StreamController controller;


### PR DESCRIPTION
With this option enabled, _ironically_, I'm not able to automatically reconnect. That would be nice to disable it.