### PR TITLE
Update build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -9,7 +9,7 @@ buildscript {
 
     dependencies {
         classpath 'com.android.tools.build:gradle:3.1.3'
-        classpath 'com.google.protobuf:protobuf-gradle-plugin:0.8.3'
+        classpath 'com.google.protobuf:protobuf-gradle-plugin:0.8.6'
     }
 }
 


### PR DESCRIPTION
Updated protobuf gradle version to resolve issues with Flutter new build android.

https://github.com/pauldemarco/flutter_blue/issues/141

Note: I also needed to update the minSDK version to 19 below in the projects default AndroidManifest.xml

```
 defaultConfig {
        // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
        applicationId "com.example.name"
        **minSdkVersion 19**
        targetSdkVersion 27
        versionCode flutterVersionCode.toInteger()
        versionName flutterVersionName
        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
    }
```

There is a deprecated code warning, but you can still build and this will enable you to work around in the mean time.