### PR TITLE
Updating the protoBuf library

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -9,7 +9,7 @@ buildscript {
 
     dependencies {
         classpath 'com.android.tools.build:gradle:3.1.3'
-        classpath 'com.google.protobuf:protobuf-gradle-plugin:0.8.3'
+        classpath 'com.google.protobuf:protobuf-gradle-plugin:0.8.7'
     }
 }
 


### PR DESCRIPTION
The Android Gradle plugin supports only Protobuf Gradle plugin version 0.8.6 and higher. Project 'flutter_blue' is using version 0.8.3.