### PR TITLE
Update bluetooth_device.dart: wait for CharacteristicWriteType.withoutResponse 

### DIFF
--- a/lib/src/bluetooth_device.dart
+++ b/lib/src/bluetooth_device.dart
@@ -114,7 +114,21 @@ class BluetoothDevice {
         .invokeMethod('writeCharacteristic', request.writeToBuffer());
 
     if (type == CharacteristicWriteType.withoutResponse) {
-      return result;
+       return await FlutterBlue.instance._methodStream
+        .where((m) => m.method == "WriteCharacteristicResponse")
+        .map((m) => m.arguments)
+        .map((buffer) =>
+            new protos.WriteCharacteristicResponse.fromBuffer(buffer))
+        .where((p) =>
+            (p.request.remoteId == request.remoteId) &&
+            (p.request.characteristicUuid == request.characteristicUuid) &&
+            (p.request.serviceUuid == request.serviceUuid))
+        .first
+        .then((w) => w.success)
+        .then((success) => (!success)
+            ? throw new Exception('Failed to write the characteristic')
+            : null)
+        .then((_) => null);
     }
 
     return await FlutterBlue.instance._methodStream


### PR DESCRIPTION
add a wait for WriteCharacteristicResponse even if type is withoutResponse.

See issue pauldemarco#168, pauldemarco#79.