### PR TITLE
Headless Background Execution

### DIFF
--- a/android/src/main/java/com/pauldemarco/flutterblue/FlutterBluePlugin.java
+++ b/android/src/main/java/com/pauldemarco/flutterblue/FlutterBluePlugin.java
@@ -84,21 +84,23 @@ public class FlutterBluePlugin implements MethodCallHandler, RequestPermissionsR
     }
 
     FlutterBluePlugin(Registrar r){
-        this.registrar = r;
-        this.channel = new MethodChannel(registrar.messenger(), NAMESPACE+"/methods");
-        this.stateChannel = new EventChannel(registrar.messenger(), NAMESPACE+"/state");
-        this.scanResultChannel = new EventChannel(registrar.messenger(), NAMESPACE+"/scanResult");
-        this.servicesDiscoveredChannel = new EventChannel(registrar.messenger(), NAMESPACE+"/servicesDiscovered");
-        this.characteristicReadChannel = new EventChannel(registrar.messenger(), NAMESPACE+"/characteristicRead");
-        this.descriptorReadChannel = new EventChannel(registrar.messenger(), NAMESPACE+"/descriptorRead");
-        this.mBluetoothManager = (BluetoothManager) r.activity().getSystemService(Context.BLUETOOTH_SERVICE);
-        this.mBluetoothAdapter = mBluetoothManager.getAdapter();
-        channel.setMethodCallHandler(this);
-        stateChannel.setStreamHandler(stateHandler);
-        scanResultChannel.setStreamHandler(scanResultsHandler);
-        servicesDiscoveredChannel.setStreamHandler(servicesDiscoveredHandler);
-        characteristicReadChannel.setStreamHandler(characteristicReadHandler);
-        descriptorReadChannel.setStreamHandler(descriptorReadHandler);
+	if (r.activity() != null) {
+        	this.registrar = r;
+        	this.channel = new MethodChannel(registrar.messenger(), NAMESPACE+"/methods");
+        	this.stateChannel = new EventChannel(registrar.messenger(), NAMESPACE+"/state");
+        	this.scanResultChannel = new EventChannel(registrar.messenger(), NAMESPACE+"/scanResult");
+        	this.servicesDiscoveredChannel = new EventChannel(registrar.messenger(), NAMESPACE+"/servicesDiscovered");
+        	this.characteristicReadChannel = new EventChannel(registrar.messenger(), NAMESPACE+"/characteristicRead");
+        	this.descriptorReadChannel = new EventChannel(registrar.messenger(), NAMESPACE+"/descriptorRead");
+        	this.mBluetoothManager = (BluetoothManager) r.activity().getSystemService(Context.BLUETOOTH_SERVICE);
+        	this.mBluetoothAdapter = mBluetoothManager.getAdapter();
+        	channel.setMethodCallHandler(this);
+        	stateChannel.setStreamHandler(stateHandler);
+        	scanResultChannel.setStreamHandler(scanResultsHandler);
+        	servicesDiscoveredChannel.setStreamHandler(servicesDiscoveredHandler);
+        	characteristicReadChannel.setStreamHandler(characteristicReadHandler);
+        	descriptorReadChannel.setStreamHandler(descriptorReadHandler);
+	}
     }
 
     @Override


### PR DESCRIPTION
Hi,
I was trying to implement a Headless Background Execution on my Application with the package [flutter_background_fetch](https://github.com/transistorsoft/flutter_background_fetch) but I was having no success. So I open an issue on GitHub and problem was that FlutterBlue was crashing my App on an Headless Context. You can see the discussion [here](https://github.com/transistorsoft/flutter_background_fetch/issues/11). The problem is that in a Headless context there isn't any Activity involved. 
The solution is just to validate if the activity is null or not! 