### PR TITLE
Enables background usage of flutter-blue

### DIFF
--- a/lib/src/flutter_blue.dart
+++ b/lib/src/flutter_blue.dart
@@ -59,6 +59,10 @@ class FlutterBlue {
         .map((s) => BluetoothState.values[s.state.value]);
   }
 
+  /// Sets a unique id (required on iOS for restoring app on background-scan)
+  /// should be called before any other methods.
+  Future setUniqueId(String uniqueid) => _channel.invokeMethod('setUniqueId',uniqueid.toString());
+  
   /// Starts a scan for Bluetooth Low Energy devices
   /// Timeout closes the stream after a specified [Duration]
   Stream<ScanResult> scan({


### PR DESCRIPTION
Android:
Swaps activity() calls for context() where only a context is required. The only place an activity is required is when requesting permissions. This patch will return an error when the plugin is used where permissions have not been granted, and there is no activity available to request permissions

iOS:
To use bluetooth-central background role and continue to processes in the background it is required that a unique ID (CBCentralManagerOptionRestoreIdentifierKey) be set when the CBCentralManager is initialized. (https://developer.apple.com/documentation/corebluetooth/cbcentralmanageroptionrestoreidentifierkey?language=objc).

Delays instanciation of the cbcentralmanager to when it is first used, so allow setting of a unique id from dart.

When CBCentralManagerOptionRestoreIdentifierKey is set, the CBCentralManagerDelegate must implement centralManager:willRestoreState. The current implementation is empty as it appears that setting a unique ID is sufficient (and the bluetooth-central role) is sufficient to stop iOS killing the app after a few minutes once it has been backgrounded iff a there is ongoing bluetooth activity (connection is active or pending, or a scan is in progress). 

This has a side effect of printing an API-MISUSE warning when CBCentralManagerOptionRestoreIdentifierKey is not used, because the method centralManager:willRestoreState is always implemented. The warning is harmless when not using CBCentralManagerOptionRestoreIdentifierKey.

Dart:

To support the setting of a unique Id, introduces setUniqueId(String). This should be called before any methods that will instanciate the native instance of the cbcentralmanager.