### PR TITLE
[ios] Change protoc path to use PODS_ROOT envar

### DIFF
--- a/ios/flutter_blue.podspec
+++ b/ios/flutter_blue.podspec
@@ -18,7 +18,7 @@ A new flutter plugin project.
   s.dependency '!ProtoCompiler'
   s.framework = 'CoreBluetooth'
 
-  protoc = ENV['PWD'] + '/Pods/!ProtoCompiler/protoc'
+  protoc = "#{PODS_ROOT}/!ProtoCompiler/protoc"
   objc_out = 'gen'
   proto_in = '../protos'
   s.prepare_command = <<-CMD


### PR DESCRIPTION
As per @malleusinferni comment [here](https://github.com/pauldemarco/flutter_blue/issues/108#issuecomment-455931209) on #108, using the environment variable PODS_ROOT is more robust than PWD.