### PR TITLE
Enables background usage of flutter-blue

### DIFF
--- a/lib/src/flutter_blue.dart
+++ b/lib/src/flutter_blue.dart
@@ -59,6 +59,10 @@ class FlutterBlue {
         .map((s) => BluetoothState.values[s.state.value]);
   }
 
+  /// Sets a unique id (required on iOS for restoring app on background-scan)
+  /// should be called before any other methods.
+  Future setUniqueId(String uniqueid) => _channel.invokeMethod('setUniqueId',uniqueid.toString());
+  
   /// Starts a scan for Bluetooth Low Energy devices
   /// Timeout closes the stream after a specified [Duration]
   Stream<ScanResult> scan({


### PR DESCRIPTION
Changed [this](https://github.com/pauldemarco/flutter_blue/pull/191) PR to come from `rmawatson:background_feature` instead of `rmawatson:master`

Android:
Swaps activity() calls for context() where only a context is required. The only place an activity is required is when requesting permissions. This patch will return an error when the plugin is used where permissions have not been granted, and there is no activity available to request permissions

iOS:
To use bluetooth-central background role and continue to processes in the background it is required that a unique ID (CBCentralManagerOptionRestoreIdentifierKey) be set when the CBCentralManager is initialized. (https://developer.apple.com/documentation/corebluetooth/cbcentralmanageroptionrestoreidentifierkey?language=objc).

Delays instanciation of the cbcentralmanager to when it is first used, so allow setting of a unique id from dart.

When CBCentralManagerOptionRestoreIdentifierKey is set, the CBCentralManagerDelegate must implement centralManager:willRestoreState. The current implmentation is empty as it appears that setting a unique ID is sufficient to stop iOS killing the app once it has been backgrounded, if a bluetooth connection is active, or a scan is in progress.

This has a side effect of printing an API-MISUSE warning when CBCentralManagerOptionRestoreIdentifierKey is not used, because the method centralManager:willRestoreState is always implemented. The warning is harmless when not using CBCentralManagerOptionRestoreIdentifierKey.

Dart:

To support the setting of a unique Id, introduces setUniqueId(String). This should be called before any methods that will instanciate the native instance of the cbcentralmanager.

Additional Notes:

iOS:

Even when a unique ID is set, the app could still theoretically be killed for other reasons by iOS (although I have not experienced this).

If the app is killed by iOS at any point and bluetooth-tasks are ongoing, iOS will restart the app and willRestoreState method will be called on the CBCentralManagerDelegate. It allows about 10 seconds to handle the event, before the app is killed again. It may be nice to allow registering a handler in flutter that can be called to handle such events. This would be iOS only.

States that can be saved and restored:

https://developer.apple.com/documentation/corebluetooth/cbcentralmanagerdelegate/central_manager_state_restoration_options?language=objc

Additionally it would be good to be able to pass through the application restart reason. Currently flutter has no way of knowing why it was started and main() will run if it was started to handle something through willRestoreState. If it was started to handle this callback, the ideal would be run this in a standalone isolate, passing the various restored states to the handler, but allow the main to exit without attempting to run any code by checking the start reason.