### PR TITLE
Require TRANSPORT_LE for connectGatt().

### DIFF
--- a/android/src/main/java/com/pauldemarco/flutterblue/FlutterBluePlugin.java
+++ b/android/src/main/java/com/pauldemarco/flutterblue/FlutterBluePlugin.java
@@ -211,7 +211,7 @@ public class FlutterBluePlugin implements MethodCallHandler, RequestPermissionsR
                 }
 
                 // New request, connect and add gattServer to Map
-                BluetoothGatt gattServer = device.connectGatt(registrar.activity(), options.getAndroidAutoConnect(), mGattCallback);
+                BluetoothGatt gattServer = device.connectGatt(registrar.activity(), options.getAndroidAutoConnect(), mGattCallback, BluetoothDevice.TRANSPORT_LE);
                 mGattServers.put(deviceId, gattServer);
                 result.success(null);
                 break;


### PR DESCRIPTION
Hi!

I did not get flutter_blue to connect to a BLE device due to _error/status 133_ received upon onClientConnectionState() in BluetoothGatt. I then realized, that I previously had the same issue when working on a "classical" Android project back a while. Fixing the issue back then took quite some research, however the problem is described here: https://stackoverflow.com/questions/25330938/android-bluetoothgatt-status-133-register-callback#25364567

This pull request adds the same fix to flutter_blue and has been successfully tested to resolve the issue in connecting to my BLE device. It was tested on a Nexus 5X running Android 8.1.0. I'm happy to help with more details if required.