### PR TITLE
add min SDK version for android

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
   package="com.pauldemarco.flutterblue">
+  <uses-sdk android:minSdkVersion="16" />
   <uses-permission android:name="android.permission.BLUETOOTH" />
   <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
   <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>


### PR DESCRIPTION
Right now flutter supports a minimum SDK version of 16 and all plugins should be able to match it, anything lower than that will probably cause some unwanted issues. We need to add those into Android Manifest and properly document it.