### PR TITLE
Catch both `/ios/Pods` and `/Pods/` paths for protoc

### DIFF
--- a/ios/flutter_blue.podspec
+++ b/ios/flutter_blue.podspec
@@ -18,7 +18,15 @@ A new flutter plugin project.
   s.dependency '!ProtoCompiler'
   s.framework = 'CoreBluetooth'
 
-  protoc = ENV['PWD'] + '/Pods/!ProtoCompiler/protoc'
+  # try with 'ios'
+  if File.exist?(ENV['PWD'] + '/ios/Pods/!ProtoCompiler/protoc')
+    protoc =  ENV['PWD'] + '/ios/Pods/!ProtoCompiler/protoc'
+  end
+  # try without 'ios'
+  if File.exist?(ENV['PWD'] + '/Pods/!ProtoCompiler/protoc')
+    protoc =  ENV['PWD'] + '/Pods/!ProtoCompiler/protoc'
+  end
+
   objc_out = 'gen'
   proto_in = '../protos'
   s.prepare_command = <<-CMD


### PR DESCRIPTION
Since the actual value of `ENV['PWD]` it's not predictable why not check if `ios/Pods/!ProtoCompiler/protoc` or `/Pods/!ProtoCompiler/protoc` exists?