### PR TITLE
Fixing problem when canceling the scan subscription.

### DIFF
--- a/lib/src/flutter_blue.dart
+++ b/lib/src/flutter_blue.dart
@@ -106,6 +106,7 @@ class FlutterBlue {
             .map((m) => m.arguments))
         .takeUntil(Observable.merge(killStreams))
         .doOnDone(stopScan)
+        .doOnCancel(stopScan)
         .map((buffer) => new protos.ScanResult.fromBuffer(buffer))
         .map((p) {
       final result = new ScanResult.fromProto(p);


### PR DESCRIPTION
When canceling a `scan` subscription, the scanner is not stopped. This causes a second scan to fail. When calling `stopScan` on `doOnCancel`, this doesn't appear.

Due to the documentation of this method they're covering 2 different scenarios.
https://pub.dev/documentation/rxdart/latest/rx/Observable/doOnDone.html
https://pub.dev/documentation/rxdart/latest/rx/Observable/doOnCancel.html

If you take the doOnDone example, subscribe to it and cancel the subscription, the text won't be shown. this is the reason why for the `scan` method both options should lead to `stopScan`