### PR TITLE
Expose `changedValue` Method to get the new changed value in BluetoothCharacteristic

### DIFF
--- a/lib/src/bluetooth_characteristic.dart
+++ b/lib/src/bluetooth_characteristic.dart
@@ -27,6 +27,10 @@ class BluetoothCharacteristic {
         _onValueChangedStream,
       ]);
 
+  Stream<List<int>> get changedValue => Observable.merge([
+        _onValueChangedStream,
+      ]);
+
   List<int> get lastValue => _value.value;
 
   BluetoothCharacteristic.fromProto(protos.BluetoothCharacteristic p)


### PR DESCRIPTION
fix issue #378