### PR TITLE
cirrus ci for both android and ios

### DIFF
--- a/.ci/Dockerfile
+++ b/.ci/Dockerfile
@@ -1,0 +1,24 @@
+FROM cirrusci/flutter:stable
+
+RUN sudo apt-get update -y
+
+RUN sudo apt-get install -y --no-install-recommends gnupg
+
+# Add repo for gcloud sdk and install it
+RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | \
+    sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list 
+
+RUN curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | \
+    sudo apt-key --keyring /usr/share/keyrings/cloud.google.gpg add -
+
+RUN sudo apt-get update && sudo apt-get install -y google-cloud-sdk && \
+    gcloud config set core/disable_usage_reporting true && \
+    gcloud config set component_manager/disable_update_check true
+
+RUN yes | sdkmanager \
+    "platforms;android-29" \
+    "build-tools;29.0.2" \
+    "extras;google;m2repository" \
+    "extras;android;m2repository"
+
+RUN yes | sdkmanager --licenses

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -28,7 +28,7 @@ task:
   create_simulator_script:
     - xcrun simctl list
     - xcrun simctl create Flutter-iPhone com.apple.CoreSimulator.SimDeviceType.iPhone-X com.apple.CoreSimulator.SimRuntime.iOS-12-2 | xargs xcrun simctl boot
-    test_script: flutter test
-    build_script: 
-      - cd example
-      - flutter build ios --no-codesign
+  test_script: flutter test
+  build_script: 
+    - cd example
+    - flutter build ios --no-codesign

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -10,7 +10,9 @@ task:
     - flutter channel stable
     - flutter upgrade
   build_script: 
-    - cd example
+    - flutter pub get
+    - cd example    
+    - flutter pub get
     - flutter build apk
   test_script: flutter test
 
@@ -29,6 +31,8 @@ task:
     - xcrun simctl list
     - xcrun simctl create Flutter-iPhone com.apple.CoreSimulator.SimDeviceType.iPhone-X com.apple.CoreSimulator.SimRuntime.iOS-12-2 | xargs xcrun simctl boot
   build_script: 
+    - flutter pub get
     - cd example
+    - flutter pub get
     - flutter build ios --no-codesign
   test_script: flutter test

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,34 @@
+task:
+  use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true' && $CIRRUS_PR == ''
+  container:
+    dockerfile: .ci/Dockerfile
+    cpu: 8
+    memory: 16G
+  pub_cache:
+    folder: ~/.pub-cache
+  setup_script:
+    - pod repo update
+    - flutter channel stable
+    - flutter upgrade
+  test_script: flutter test
+  build_script: 
+    - cd example
+    - flutter build apk
+
+task:
+  use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true'
+  osx_instance:
+    image: mojave-xcode-10.2-flutter
+  pub_cache:
+    folder: ~/.pub-cache
+  setup_script:
+    - pod repo update
+    - flutter channel stable
+    - flutter upgrade
+  create_simulator_script:
+    - xcrun simctl list
+    - xcrun simctl create Flutter-iPhone com.apple.CoreSimulator.SimDeviceType.iPhone-X com.apple.CoreSimulator.SimRuntime.iOS-12-2 | xargs xcrun simctl boot
+    test_script: flutter test
+    build_script: 
+      - cd example
+      - flutter build ios --no-codesign

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -7,7 +7,7 @@ task:
   pub_cache:
     folder: ~/.pub-cache
   setup_script:
-    - flutter channel stable
+    - flutter channel dev
     - flutter upgrade
   build_script: 
     - flutter pub get
@@ -25,7 +25,7 @@ task:
     folder: ~/.pub-cache
   setup_script:
     - pod repo update
-    - flutter channel stable
+    - flutter channel dev
     - flutter upgrade
   create_simulator_script:
     - xcrun simctl list

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -7,18 +7,18 @@ task:
   pub_cache:
     folder: ~/.pub-cache
   setup_script:
-    - pod repo update
     - flutter channel stable
     - flutter upgrade
-  test_script: flutter test
   build_script: 
     - cd example
     - flutter build apk
+  test_script: flutter test
 
 task:
   use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true'
   osx_instance:
-    image: mojave-xcode-10.2-flutter
+    #image: mojave-xcode-10.2-flutter
+    image: mojave-flutter
   pub_cache:
     folder: ~/.pub-cache
   setup_script:
@@ -28,7 +28,7 @@ task:
   create_simulator_script:
     - xcrun simctl list
     - xcrun simctl create Flutter-iPhone com.apple.CoreSimulator.SimDeviceType.iPhone-X com.apple.CoreSimulator.SimRuntime.iOS-12-2 | xargs xcrun simctl boot
-  test_script: flutter test
   build_script: 
     - cd example
     - flutter build ios --no-codesign
+  test_script: flutter test

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -37,7 +37,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'com.google.protobuf'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 29
 
     defaultConfig {
         minSdkVersion 19

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -25,7 +25,7 @@ apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 29
 
     lintOptions {
         disable 'InvalidPackage'

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -34,7 +34,7 @@ android {
     defaultConfig {
         applicationId "com.pauldemarco.flutter_blue_example"
         minSdkVersion 19
-        targetSdkVersion 28
+        targetSdkVersion 29
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/ios/flutter_blue.podspec
+++ b/ios/flutter_blue.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
   s.summary          = 'Bluetooth Low Energy plugin for Flutter.'
   s.description      = <<-DESC
 Bluetooth Low Energy plugin for Flutter.
-                       DESC
+                      DESC
   s.homepage         = 'https://github.com/pauldemarco/flutter_blue'
   s.license          = { :file => '../LICENSE' }
   s.author           = { 'Paul DeMarco' => 'paulmdemarco@gmail.com' }
@@ -16,17 +16,38 @@ Bluetooth Low Energy plugin for Flutter.
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
+  s.dependency '!ProtoCompiler'
   s.platform = :ios, '8.0'
   s.framework = 'CoreBluetooth'
 
+  podspec_dir = File.dirname(__FILE__)
+  protoc_dir = File.join(ENV['PWD'], 'ios/Pods/!ProtoCompiler')
+  protoc = File.join(protoc_dir, 'protoc')
+  objc_out = 'gen'
+  proto_in = '../protos'
+  s.prepare_command = <<-CMD
+    cd #{podspec_dir}
+    mkdir -p #{objc_out}
+    #{protoc} \
+      -I=#{proto_in} -I=#{protoc_dir} \
+      --objc_out=#{objc_out} \
+      #{proto_in}/*.proto
+  CMD
+
   s.subspec 'Protos' do |ss|
-    ss.source_files = 'gen/**/*.pbobjc.{h,m}'
-    ss.header_mappings_dir = '.'
+    ss.source_files = 'gen/**/*'
+    ss.public_header_files = 'gen/**/*.h'
+    ss.header_mappings_dir = 'gen'
     ss.requires_arc = false
     ss.dependency 'Protobuf'
   end
 
   # Flutter.framework does not contain a i386 slice. Only x86_64 simulators are supported.
-  s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'VALID_ARCHS[sdk=iphonesimulator*]' => 'x86_64', }
+  # GCC_PREPROCESSOR_DEFINITIONS is needed by all pods that depend on Protobuf
+  s.pod_target_xcconfig = {
+    'DEFINES_MODULE' => 'YES',
+    'VALID_ARCHS[sdk=iphonesimulator*]' => 'x86_64',
+    'GCC_PREPROCESSOR_DEFINITIONS' => '$(inherited) GPB_USE_PROTOBUF_FRAMEWORK_IMPORTS=1',
+  }
 
 end


### PR DESCRIPTION
To fix ios build, this PR includes https://github.com/pauldemarco/flutter_blue/pull/403
There're 2 outstanding issues right now:
1. Android build does not work with flutter stable channel, thus I use dev channel in CI
2. Although build passes, flutter test fails for both android and ios, which can be fixed later

To enable cirrus CI (free for open source project), go to https://github.com/marketplace/cirrus-ci and follow instructions here: https://cirrus-ci.org/guide/quick-start/

@pauldemarco  plz take a look and let me know your concerns.  