### PR TITLE
Avoid Range error when no BT adapter is available,

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -51,7 +51,7 @@ class BluetoothOffScreen extends StatelessWidget {
               color: Colors.white54,
             ),
             Text(
-              'Bluetooth Adapter is ${state.toString().substring(15)}.',
+              'Bluetooth Adapter is ${state != null ? state.toString().substring(15): 'not available'}.',
               style: Theme.of(context)
                   .primaryTextTheme
                   .subhead


### PR DESCRIPTION
 Avoid Range error when no BT adapter is available, e.g. when running on emulator

Signed-off-by: Bernhard Bender <ber.droid@googlemail.com>