### PR TITLE
Fix `error: package androidx.core.app does not exist`

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -46,6 +46,9 @@ android {
     lintOptions {
         disable 'InvalidPackage'
     }
+    dependencies {
+        implementation 'androidx.core:core:1.1.0'
+    }
     sourceSets {
         main {
             proto {


### PR DESCRIPTION
Hi there!

A clean checkout of the flutter_blue example and other Flutter projects using flutter_blue do not build due to the missing `androidx.core.app` dependency removed in commit 2ccdc68d474c158ae7cfbcae993e430a578173ec

See https://stackoverflow.com/questions/58603255/error-package-androidx-core-app-does-not-exist-when-running-flutter-blue-plugin

This pull request readds the required dependencies in the gradle file.

Do you plan to remove the dependency on `androidx.core.app` in the near future?

Best regards and thanks for your hard work 😄👍

Markus alias @atokulus

