### PR TITLE
Fixed Issue with Bluetooth Permissions on iOS 13.3

### DIFF
--- a/example/ios/Runner/Info.plist
+++ b/example/ios/Runner/Info.plist
@@ -39,6 +39,10 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>NSBluetoothAlwaysUsageDescription</key>
+	<string>We need BT access because it&apos;s a BT App.</string>
+	<key>NSBluetoothPeripheralUsageDescription</key>
+	<string>We need BT access because it&apos;s a BT App.</string>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
 </dict>


### PR DESCRIPTION
This change is necessary as of iOS 13.3. Without it the example app just crashes with no errors or warnings, because... Apple.