### PR TITLE
Bump minimum iOS version from 8 to 10

### DIFF
--- a/ios/flutter_blue.podspec
+++ b/ios/flutter_blue.podspec
@@ -16,7 +16,7 @@ Bluetooth Low Energy plugin for Flutter.
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
-  s.platform = :ios, '8.0'
+  s.platform = :ios, '10.0'
   s.framework = 'CoreBluetooth'
 
   s.subspec 'Protos' do |ss|


### PR DESCRIPTION
This should fix the version warnings of #504. Be aware that #478 fixes a separate issue in the same file. Fixing the versioning issue might make that one pop up. Hence they both should get merged.