### PR TITLE
Remove minSdk declaration from AndroidManifest.xml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.6.4
+* Removes minSdk declaration from AndroidManifest.xml
+
 ## 0.6.3+1
 * Fix compilation issue with iOS
 * Bump protobuf version to 1.0.0

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
   package="com.pauldemarco.flutter_blue">
-  <uses-sdk android:minSdkVersion="18" />
   <uses-permission android:name="android.permission.BLUETOOTH" />
   <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
   <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: flutter_blue
 description:
   Flutter plugin for connecting and communicating with Bluetooth Low Energy devices,
   on Android and iOS
-version: 0.6.3+1
+version: 0.6.4
 author: Paul DeMarco <paulmdemarco@gmail.com>
 homepage: https://github.com/pauldemarco/flutter_blue
 


### PR DESCRIPTION
Fixes #332.

It's sufficient to declare this property in build.gradle now.