### PR TITLE
Stop notifying of value changes when a write happens

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -176,9 +176,14 @@ class DeviceScreen extends StatelessWidget {
                   (c) => CharacteristicTile(
                     characteristic: c,
                     onReadPressed: () => c.read(),
-                    onWritePressed: () => c.write(_getRandomBytes()),
-                    onNotificationPressed: () =>
-                        c.setNotifyValue(!c.isNotifying),
+                    onWritePressed: () async {
+                      await c.write(_getRandomBytes(), withoutResponse: true);
+                      await c.read();
+                    },
+                    onNotificationPressed: () async {
+                      await c.setNotifyValue(!c.isNotifying);
+                      await c.read();
+                    },
                     descriptorTiles: c.descriptors
                         .map(
                           (d) => DescriptorTile(

--- a/lib/src/bluetooth_characteristic.dart
+++ b/lib/src/bluetooth_characteristic.dart
@@ -54,8 +54,6 @@ class BluetoothCharacteristic {
           .map((c) {
         // Update the characteristic with the new values
         _updateDescriptors(c.descriptors);
-//        _value.add(c.lastValue);
-//        print('c.lastValue: ${c.lastValue}');
         return c;
       });
 
@@ -123,7 +121,6 @@ class BluetoothCharacteristic {
         .invokeMethod('writeCharacteristic', request.writeToBuffer());
 
     if (type == CharacteristicWriteType.withoutResponse) {
-      _value.add(value);
       return result;
     }
 
@@ -141,7 +138,6 @@ class BluetoothCharacteristic {
         .then((success) => (!success)
             ? throw new Exception('Failed to write the characteristic')
             : null)
-        .then((_) => _value.add(value))
         .then((_) => null);
   }
 
@@ -168,7 +164,6 @@ class BluetoothCharacteristic {
         .then((p) => new BluetoothCharacteristic.fromProto(p.characteristic))
         .then((c) {
       _updateDescriptors(c.descriptors);
-      _value.add(c.lastValue);
       return (c.isNotifying == notify);
     });
   }


### PR DESCRIPTION
This PR fixes the short-circuit value notifications that were happening when performing a write.
Now, characteristic's value streams will only emit changes if notifying, or if a manual read is performed by the user.
This should help align flutter_blue with the operation of other BLE plugins the user might be familiar with.