### PR TITLE
Performance fix for Guid initializers

### DIFF
--- a/lib/src/guid.dart
+++ b/lib/src/guid.dart
@@ -43,27 +43,20 @@ class Guid {
     return bytes;
   }
 
-  static List<int> _fromString(input) {
-    var bytes = new List<int>.filled(16, 0);
+  static List<int> _fromString(String input) {
     if (input == null) {
       throw new ArgumentError("Input was null");
     }
-    if (input.length < 32) {
-      throw new FormatException("The format is invalid");
-    }
-    input = input.toLowerCase();
 
-    final RegExp regex = new RegExp('[0-9a-f]{2}');
-    Iterable<Match> matches = regex.allMatches(input);
-    if (matches.length != 16) {
+    input = input.replaceAll('-', '');
+    input = input.replaceAll('{', '');
+    input = input.replaceAll('}', '');
+    final bytes = hex.decode(input);
+
+    if (bytes.length != 16) {
       throw new FormatException("The format is invalid");
     }
-    int i = 0;
-    for (Match match in matches) {
-      var hexString = input.substring(match.start, match.end);
-      bytes[i] = hex.decode(hexString)[0];
-      i++;
-    }
+
     return bytes;
   }
 

--- a/lib/src/guid.dart
+++ b/lib/src/guid.dart
@@ -18,29 +18,21 @@ class Guid {
 
   Guid.empty() : this._internal(new List.filled(16, 0));
 
-  static List<int> _fromMacString(input) {
-    var bytes = new List<int>.filled(16, 0);
-
+  static List<int> _fromMacString(String input) {
     if (input == null) {
       throw new ArgumentError("Input was null");
     }
-    input = input.toLowerCase();
 
-    final RegExp regex = new RegExp('[0-9a-f]{2}');
-    Iterable<Match> matches = regex.allMatches(input);
+    input = input.replaceAll(':', '');
+    input = input.replaceAll('{', '');
+    input = input.replaceAll('}', '');
+    final bytes = hex.decode(input);
 
-    if (matches.length != 6) {
+    if (bytes.length != 6) {
       throw new FormatException("The format is invalid: " + input);
     }
 
-    int i = 0;
-    for (Match match in matches) {
-      var hexString = input.substring(match.start, match.end);
-      bytes[i] = hex.decode(hexString)[0];
-      i++;
-    }
-
-    return bytes;
+    return bytes + List<int>.filled(10, 0);
   }
 
   static List<int> _fromString(String input) {

--- a/lib/src/guid.dart
+++ b/lib/src/guid.dart
@@ -23,9 +23,7 @@ class Guid {
       throw new ArgumentError("Input was null");
     }
 
-    input = input.replaceAll(':', '');
-    input = input.replaceAll('{', '');
-    input = input.replaceAll('}', '');
+    input = _removeNonHexCharacters(input);
     final bytes = hex.decode(input);
 
     if (bytes.length != 6) {
@@ -40,9 +38,7 @@ class Guid {
       throw new ArgumentError("Input was null");
     }
 
-    input = input.replaceAll('-', '');
-    input = input.replaceAll('{', '');
-    input = input.replaceAll('}', '');
+    input = _removeNonHexCharacters(input);
     final bytes = hex.decode(input);
 
     if (bytes.length != 16) {
@@ -50,6 +46,14 @@ class Guid {
     }
 
     return bytes;
+  }
+
+  static String _removeNonHexCharacters(String sourceString) {
+    return String.fromCharCodes(sourceString.runes.where((r) =>
+      (r >= 48 && r <= 57) // characters 0 to 9
+      || (r >= 65 && r <= 70)  // characters A to F
+      || (r >= 97 && r <= 102) // characters a to f
+    ));
   }
 
   static int _calcHashCode(List<int> bytes) {


### PR DESCRIPTION
This PR aims at fixing a performance pitfall in the current implementation of Guid initializers.
Both `Guid(String input)` and `Guid.fromMac(String input)` perform a test on the input String through `_fromString` and `_fromMacString` methods respectively. The test is operated using a regular expression to catch the expected number of hex couples and decode them to a list of bytes:
```
final RegExp regex = new RegExp('[0-9a-f]{2}');
```

The problem with this approach is the performance cost of performing a Regex every time a Guid is created either by a client application (which might be negligible) or by flutter_blue itself (which hits the Guid initializer a _lot_ of times).
Even if Dart is not particularly [slow on regex](https://github.com/mariomka/regex-benchmark), flutter_blue uses the Guid initializers very frequently, especially in those scenarios when a BT characteristic is read/written/indicated at short intervals.

To verify this behavior I profiled a small application that reads from a characteristic about 2 times in a second.
![Schermata 2020-04-18 alle 10 52 58](https://user-images.githubusercontent.com/6697707/79634820-3f33d000-816d-11ea-82be-1517074fb96c.png)
As you can see from the above flame chart, a lot of time is spent in `Guid._fromString` method.

In this PR i modified both `_fromString` and `_fromMacString` methods not to use any regex check but instead simply decode the input string to hex bytes after all non-hex characters are stripped from it.
The procedure to remove non-hex character has also been improved to run in a single pass, instead of three consecutive `.replaceAll` calls.
All the preexisting checks regarding the expected length of bytes are still left intact, all the tests in `guid_tests.dart` are passing.

Profiling the same application after the optimizations yields the following flame chart:
![Schermata 2020-04-18 alle 11 26 05](https://user-images.githubusercontent.com/6697707/79635067-ea915480-816e-11ea-8d86-1b121c643608.png)

As you can see,  cpu time is now better distributed across framework tasks and the disproportion of `Guid` methods is no longer perceivable.

