### PR TITLE
requestMtu return is missing await keyword

### DIFF
--- a/lib/src/bluetooth_device.dart
+++ b/lib/src/bluetooth_device.dart
@@ -128,7 +128,7 @@ class BluetoothDevice {
       ..remoteId = id.toString()
       ..mtu = desiredMtu;
 
-    return FlutterBlue.instance._channel
+    return await FlutterBlue.instance._channel
         .invokeMethod('requestMtu', request.writeToBuffer());
   }
 

--- a/lib/src/bluetooth_device.dart
+++ b/lib/src/bluetooth_device.dart
@@ -121,23 +121,25 @@ class BluetoothDevice {
         .map((p) => p.mtu);
   }
 
-  /// Request to change the MTU Size
+  /// Request to change the MTU Size and returns the response back
   /// Throws error if request did not complete successfully
-  Future<void> requestMtu(int desiredMtu) async {
+  Future<int> requestMtu(int desiredMtu) async {
     var request = protos.MtuSizeRequest.create()
       ..remoteId = id.toString()
       ..mtu = desiredMtu;
 
-    await FlutterBlue.instance._channel
-        .invokeMethod('requestMtu', request.writeToBuffer());
-    
-    await FlutterBlue.instance._methodStream
+    var response = FlutterBlue.instance._methodStream
         .where((m) => m.method == "MtuSize")
         .map((m) => m.arguments)
         .map((buffer) => protos.MtuSizeResponse.fromBuffer(buffer))
         .where((p) => p.remoteId == id.toString())
         .map((p) => p.mtu)
         .first;
+
+    await FlutterBlue.instance._channel
+        .invokeMethod('requestMtu', request.writeToBuffer());
+
+    return response;
   }
 
   /// Indicates whether the Bluetooth Device can send a write without response

--- a/lib/src/bluetooth_device.dart
+++ b/lib/src/bluetooth_device.dart
@@ -128,8 +128,16 @@ class BluetoothDevice {
       ..remoteId = id.toString()
       ..mtu = desiredMtu;
 
-    return await FlutterBlue.instance._channel
+    await FlutterBlue.instance._channel
         .invokeMethod('requestMtu', request.writeToBuffer());
+    
+    await FlutterBlue.instance._methodStream
+        .where((m) => m.method == "MtuSize")
+        .map((m) => m.arguments)
+        .map((buffer) => protos.MtuSizeResponse.fromBuffer(buffer))
+        .where((p) => p.remoteId == id.toString())
+        .map((p) => p.mtu)
+        .first;
   }
 
   /// Indicates whether the Bluetooth Device can send a write without response


### PR DESCRIPTION
In some cases write operations will fail, sending data will be started before setting mtu value, because the promise is never awaited.