### PR TITLE
Don't initialize CBCentralManager until needed

### DIFF
--- a/ios/Classes/FlutterBluePlugin.m
+++ b/ios/Classes/FlutterBluePlugin.m
@@ -48,7 +48,6 @@ typedef NS_ENUM(NSUInteger, LogLevel) {
   FlutterEventChannel* stateChannel = [FlutterEventChannel eventChannelWithName:NAMESPACE @"/state" binaryMessenger:[registrar messenger]];
   FlutterBluePlugin* instance = [[FlutterBluePlugin alloc] init];
   instance.channel = channel;
-  instance.centralManager = [[CBCentralManager alloc] initWithDelegate:instance queue:nil];
   instance.scannedPeripherals = [NSMutableDictionary new];
   instance.servicesThatNeedDiscovered = [NSMutableArray new];
   instance.characteristicsThatNeedDiscovered = [NSMutableArray new];
@@ -63,6 +62,9 @@ typedef NS_ENUM(NSUInteger, LogLevel) {
 }
 
 - (void)handleMethodCall:(FlutterMethodCall*)call result:(FlutterResult)result {
+  if (self.centralManager == nil) {
+    self.centralManager = [[CBCentralManager alloc] initWithDelegate:self queue:nil];
+  }
   if ([@"setLogLevel" isEqualToString:call.method]) {
     NSNumber *logLevelIndex = [call arguments];
     _logLevel = (LogLevel)[logLevelIndex integerValue];


### PR DESCRIPTION
By deferring the initialization of `CBCentralManager`, we are able to
defer prompting for Bluetooth permission on iOS until a flutter_blue
method is called. Otherwise, the Bluetooth permission prompt appears
right when the app starts up.