### PR TITLE
Update protobuf dependencies

### DIFF
--- a/ios/flutter_blue.podspec
+++ b/ios/flutter_blue.podspec
@@ -23,7 +23,7 @@ Bluetooth Low Energy plugin for Flutter.
     ss.source_files = "gen/*.pbobjc.{h,m}", "gen/**/*.pbobjc.{h,m}"
     ss.header_mappings_dir = "gen"
     ss.requires_arc = false
-    ss.dependency "Protobuf", '~> 3.11.4'
+    ss.dependency "Protobuf", '>= 3.11.4', '~> 3.11'
   end
 
   # Flutter.framework does not contain a i386 slice. Only x86_64 simulators are supported.

--- a/macos/flutter_blue.podspec
+++ b/macos/flutter_blue.podspec
@@ -23,7 +23,7 @@ Bluetooth Low Energy plugin for Flutter.
     ss.source_files = "gen/*.pbobjc.{h,m}", "gen/**/*.pbobjc.{h,m}"
     ss.header_mappings_dir = "gen"
     ss.requires_arc = false
-    ss.dependency "Protobuf", '~> 3.11.4'
+    ss.dependency "Protobuf", '>= 3.11.4', '~> 3.11'
   end
 
   s.pod_target_xcconfig = {


### PR DESCRIPTION
Dependency version requirements '\~> 3.11.4' cannot be updated to 3.12 and because of that, this plugin is incompatible with the Firebase Performance plugin who have protobuf version requirements '(\~> 3.12)'.
