### PR TITLE
enable background usage on android with v2 embedding

### DIFF
--- a/android/src/main/java/com/pauldemarco/flutter_blue/FlutterBluePlugin.java
+++ b/android/src/main/java/com/pauldemarco/flutter_blue/FlutterBluePlugin.java
@@ -999,7 +999,12 @@ public class FlutterBluePlugin implements FlutterPlugin, MethodCallHandler, Requ
         new Handler(Looper.getMainLooper()).post(new Runnable() {
             @Override
             public void run() {
-                channel.invokeMethod(name, byteArray);
+                //Could already be teared down at this moment
+                if(channel!=null)  {
+                    channel.invokeMethod(name, byteArray);
+                }else {
+                    Log.w(TAG,"Tried to call " + String.valueOf(name) + " on closed channel");
+                }
             }
         });
     }

--- a/android/src/main/java/com/pauldemarco/flutter_blue/FlutterBluePlugin.java
+++ b/android/src/main/java/com/pauldemarco/flutter_blue/FlutterBluePlugin.java
@@ -240,6 +240,22 @@ public class FlutterBluePlugin implements FlutterPlugin, MethodCallHandler, Requ
                 break;
             }
 
+            case "turnOn":
+            {
+                if (!mBluetoothAdapter.isEnabled()) {
+                    result.success(mBluetoothAdapter.enable());
+                }
+                break;
+            }
+
+            case "turnOff":
+            {
+                if (mBluetoothAdapter.isEnabled()) {
+                    result.success(mBluetoothAdapter.disable());
+                }
+                break;
+            }
+
             case "startScan":
             {
                 if (ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_FINE_LOCATION)

--- a/android/src/main/java/com/pauldemarco/flutter_blue/FlutterBluePlugin.java
+++ b/android/src/main/java/com/pauldemarco/flutter_blue/FlutterBluePlugin.java
@@ -106,7 +106,7 @@ public class FlutterBluePlugin implements FlutterPlugin, MethodCallHandler, Requ
 
     @Override
     public void onAttachedToEngine(FlutterPluginBinding binding) {
-        Log.i(TAG, "onAttachedEngine");
+        Log.d(TAG, "onAttachedEngine");
         pluginBinding = binding;
         setup(
                 pluginBinding.getBinaryMessenger(),
@@ -117,34 +117,34 @@ public class FlutterBluePlugin implements FlutterPlugin, MethodCallHandler, Requ
 
     @Override
     public void onDetachedFromEngine(FlutterPluginBinding binding) {
-        Log.i(TAG, "onDetachedEngine");
+        Log.d(TAG, "onDetachedEngine");
         pluginBinding = null;
         tearDown();
     }
 
     @Override
     public void onAttachedToActivity(ActivityPluginBinding binding) {
-        Log.i(TAG, "onAttached");
+        Log.d(TAG, "onAttached");
         activityBinding = binding;
         activityBinding.addRequestPermissionsResultListener(this);
     }
 
     @Override
     public void onDetachedFromActivity() {
-        Log.i(TAG, "onDetached");
+        Log.d(TAG, "onDetached");
         activityBinding.removeRequestPermissionsResultListener(this);
         activityBinding = null;
     }
 
     @Override
     public void onDetachedFromActivityForConfigChanges() {
-        Log.i(TAG, "onDetachedConfig");
+        Log.d(TAG, "onDetachedConfig");
         onDetachedFromActivity();
     }
 
     @Override
     public void onReattachedToActivityForConfigChanges(ActivityPluginBinding binding) {
-        Log.i(TAG, "onReattachConfig");
+        Log.d(TAG, "onReattachConfig");
         onAttachedToActivity(binding);
     }
 
@@ -153,7 +153,7 @@ public class FlutterBluePlugin implements FlutterPlugin, MethodCallHandler, Requ
             final Application application,
             final PluginRegistry.Registrar registrar) {
         synchronized (initializationLock) {
-            Log.i(TAG, "setup");
+            Log.d(TAG, "setup");
             this.application = application;
             this.context = application;
             channel = new MethodChannel(messenger, NAMESPACE + "/methods");
@@ -171,7 +171,7 @@ public class FlutterBluePlugin implements FlutterPlugin, MethodCallHandler, Requ
 
     private void tearDown() {
         synchronized (tearDownLock)  {
-            Log.i(TAG, "teardown");
+            Log.d(TAG, "teardown");
             context = null;
             channel.setMethodCallHandler(null);
             channel = null;

--- a/lib/src/flutter_blue.dart
+++ b/lib/src/flutter_blue.dart
@@ -42,7 +42,9 @@ class FlutterBlue {
   ///
   ///returns false if an error occured or bluetooth is already running
   ///
-  Future<bool> turnOn() => _channel.invokeMethod('turnOn').then<bool>((d) => d);
+  Future<bool> turnOn() {
+    return _channel.invokeMethod('turnOn').then<bool>((d) => d);
+  }
 
   ///Tries to turn off Bluetooth,
   ///
@@ -51,8 +53,9 @@ class FlutterBlue {
   ///
   ///returns false if an error occured
   ///
-  Future<bool> turnOff() =>
-      _channel.invokeMethod('turnOff').then<bool>((d) => d);
+  Future<bool> turnOff() {
+    return _channel.invokeMethod('turnOff').then<bool>((d) => d);
+  }
 
   BehaviorSubject<bool> _isScanning = BehaviorSubject.seeded(false);
   Stream<bool> get isScanning => _isScanning.stream;

--- a/lib/src/flutter_blue.dart
+++ b/lib/src/flutter_blue.dart
@@ -35,6 +35,25 @@ class FlutterBlue {
   /// Checks if Bluetooth functionality is turned on
   Future<bool> get isOn => _channel.invokeMethod('isOn').then<bool>((d) => d);
 
+  ///Tries to turn on Bluetooth,
+  ///
+  ///returns true if bluetooth is being turned on.
+  ///You have to listen for a stateChange to ON to ensure bluetooth is already running
+  ///
+  ///returns false if an error occured or bluetooth is already running
+  ///
+  Future<bool> turnOn() => _channel.invokeMethod('turnOn').then<bool>((d) => d);
+
+  ///Tries to turn off Bluetooth,
+  ///
+  ///returns true if bluetooth is being turned off.
+  ///You have to listen for a stateChange to OFF to ensure bluetooth is turned off
+  ///
+  ///returns false if an error occured
+  ///
+  Future<bool> turnOff() =>
+      _channel.invokeMethod('turnOff').then<bool>((d) => d);
+
   BehaviorSubject<bool> _isScanning = BehaviorSubject.seeded(false);
   Stream<bool> get isScanning => _isScanning.stream;
 


### PR DESCRIPTION
Changes to initialization code, on android because with v2 embedding onAttachedToActivity is not called when using the plugin from within an isolate (tested with isolate_handler and foreground_service).


I also noticed some complications when using the plugin in different isolates, eg. listeners on BluetoothGatt still being called after teardown.