### PR TITLE
Exposing onValueChangedStream to avoid duplicate notifications

### DIFF
--- a/lib/src/bluetooth_characteristic.dart
+++ b/lib/src/bluetooth_characteristic.dart
@@ -21,6 +21,8 @@ class BluetoothCharacteristic {
     }
   }
 
+  Stream<List<int>> get onValueChangedStream => _onValueChangedStream;
+
   BehaviorSubject<List<int>> _value;
   Stream<List<int>> get value => Rx.merge([
         _value.stream,


### PR DESCRIPTION
This exposing onValueChangedStream to avoid the issue described in pauldemarco/flutter_blue#525

We only want to access the changed value without risk of duplicates after reconnecting our device. We welcome feedback and other ideas on how to solve this.