### PR TITLE
Expose onValueChangedStream

### DIFF
--- a/lib/src/bluetooth_characteristic.dart
+++ b/lib/src/bluetooth_characteristic.dart
@@ -24,7 +24,7 @@ class BluetoothCharacteristic {
   BehaviorSubject<List<int>> _value;
   Stream<List<int>> get value => Rx.merge([
         _value.stream,
-        _onValueChangedStream,
+        onValueChangedStream,
       ]);
 
   List<int> get lastValue => _value.value ?? [];
@@ -57,7 +57,7 @@ class BluetoothCharacteristic {
         return c;
       });
 
-  Stream<List<int>> get _onValueChangedStream =>
+  Stream<List<int>> get onValueChangedStream =>
       _onCharacteristicChangedStream.map((c) => c.lastValue);
 
   void _updateDescriptors(List<BluetoothDescriptor> newDescriptors) {


### PR DESCRIPTION
Some request/response APIs require that we can get the first new value of a characteristic after sending a request.