### PR TITLE
Added a condition for the protoc artifact so builds on M1 macs can work

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -40,7 +40,11 @@ android {
 
 protobuf {
     protoc {
-        artifact = 'com.google.protobuf:protoc:3.11.4'
+        if (project.hasProperty('protoc_platform')) {
+            artifact = "com.google.protobuf:protoc:3.11.4:${protoc_platform}"
+        } else {
+            artifact = "com.google.protobuf:protoc:3.11.4"
+        }
     }
     generateProtoTasks {
         all().each { task ->

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -40,11 +40,7 @@ android {
 
 protobuf {
     protoc {
-        if (project.hasProperty('protoc_platform')) {
-            artifact = "com.google.protobuf:protoc:3.11.4:${protoc_platform}"
-        } else {
-            artifact = "com.google.protobuf:protoc:3.11.4"
-        }
+        artifact = 'com.google.protobuf:protoc:3.17.3'
     }
     generateProtoTasks {
         all().each { task ->
@@ -58,5 +54,5 @@ protobuf {
 }
 
 dependencies {
-    implementation 'com.google.protobuf:protobuf-javalite:3.11.4'
+   implementation 'com.google.protobuf:protobuf-javalite:3.17.3'
 }


### PR DESCRIPTION
This fix didn't used to be necessary. I'm not sure what broke but this fixes it.

You need to add `protoc_platform=osx-x86_64` to your flutter project's build.gradle file on M1 macs for this fix to do anything.