### PR TITLE
Added pairing function for Android

### DIFF
--- a/android/src/main/java/com/pauldemarco/flutter_blue/FlutterBluePlugin.java
+++ b/android/src/main/java/com/pauldemarco/flutter_blue/FlutterBluePlugin.java
@@ -315,6 +315,15 @@ public class FlutterBluePlugin implements FlutterPlugin, ActivityAware, MethodCa
                 break;
             }
 
+            case "pair":
+            {
+                String deviceId = (String)call.arguments;
+                BluetoothDevice device = mBluetoothAdapter.getRemoteDevice(deviceId);
+                device.createBond();
+                result.success(null);
+                break;
+            }
+
             case "disconnect":
             {
                 String deviceId = (String)call.arguments;

--- a/lib/flutter_blue.dart
+++ b/lib/flutter_blue.dart
@@ -5,6 +5,7 @@
 library flutter_blue;
 
 import 'dart:async';
+import 'dart:io';
 
 import 'package:collection/collection.dart';
 import 'package:convert/convert.dart';

--- a/lib/src/bluetooth_device.dart
+++ b/lib/src/bluetooth_device.dart
@@ -44,6 +44,12 @@ class BluetoothDevice {
     return;
   }
 
+  /// Send a pairing request to the device.
+  /// Currently only implemented on Android.
+  Future<void> pair() async {
+    return FlutterBlue.instance._channel.invokeMethod('pair', id.toString());
+  }
+
   /// Cancels connection to the Bluetooth Device
   Future disconnect() =>
       FlutterBlue.instance._channel.invokeMethod('disconnect', id.toString());

--- a/lib/src/bluetooth_device.dart
+++ b/lib/src/bluetooth_device.dart
@@ -47,7 +47,9 @@ class BluetoothDevice {
   /// Send a pairing request to the device.
   /// Currently only implemented on Android.
   Future<void> pair() async {
-    return FlutterBlue.instance._channel.invokeMethod('pair', id.toString());
+    if (Platform.isAndroid) {
+      return FlutterBlue.instance._channel.invokeMethod('pair', id.toString());
+    }
   }
 
   /// Cancels connection to the Bluetooth Device


### PR DESCRIPTION
Added native code to call device.createBond() on Android. I'm not sure if there is an equivalent on iOS.