### PR TITLE
Null reference exception

### DIFF
--- a/android/src/main/java/com/pauldemarco/flutter_blue/FlutterBluePlugin.java
+++ b/android/src/main/java/com/pauldemarco/flutter_blue/FlutterBluePlugin.java
@@ -999,7 +999,9 @@ public class FlutterBluePlugin implements FlutterPlugin, ActivityAware, MethodCa
                 new Runnable() {
                     @Override
                     public void run() {
-                        channel.invokeMethod(name, byteArray);
+                        if(channel != null) {
+                            channel.invokeMethod(name, byteArray);
+                        }
                     }
                 });
     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   flutter:
     sdk: flutter
   convert: ^3.0.0
-  protobuf: ^2.0.0
+  protobuf: ^2.1.0
   rxdart: ^0.26.0
   collection: ^1.15.0
   meta: ^1.3.0


### PR DESCRIPTION
Sometimes, an exception is thrown because channel is null. 