### PR TITLE
Add `FlutterBlue.name` to get the human readable device name

### DIFF
--- a/android/src/main/java/com/pauldemarco/flutter_blue/FlutterBluePlugin.java
+++ b/android/src/main/java/com/pauldemarco/flutter_blue/FlutterBluePlugin.java
@@ -230,6 +230,15 @@ public class FlutterBluePlugin implements FlutterPlugin, ActivityAware, MethodCa
                 break;
             }
 
+	    case "name":
+	    {
+                String name = mBluetoothAdapter.getName();
+                if (name == null)
+                    name = "";
+                result.success(name);
+                break;
+	    }
+
             case "isOn":
             {
                 result.success(mBluetoothAdapter.isEnabled());

--- a/ios/Classes/FlutterBluePlugin.m
+++ b/ios/Classes/FlutterBluePlugin.m
@@ -82,6 +82,8 @@ typedef NS_ENUM(NSUInteger, LogLevel) {
     } else {
       result(@(NO));
     }
+  } else if([@"name" isEqualToString:call.method]) {
+    result([[UIDevice currentDevice] name]);
   } else if([@"startScan" isEqualToString:call.method]) {
     // Clear any existing scan results
     [self.scannedPeripherals removeAllObjects];

--- a/lib/src/flutter_blue.dart
+++ b/lib/src/flutter_blue.dart
@@ -32,6 +32,10 @@ class FlutterBlue {
   Future<bool> get isAvailable =>
       _channel.invokeMethod('isAvailable').then<bool>((d) => d);
 
+  /// Return the friendly Bluetooth name of the local Bluetooth adapter
+  Future<String> get name =>
+      _channel.invokeMethod('name').then<String>((d) => d);
+
   /// Checks if Bluetooth functionality is turned on
   Future<bool> get isOn => _channel.invokeMethod('isOn').then<bool>((d) => d);
 


### PR DESCRIPTION
First - thanks for your wonderful project.

This PR implements a new `FlutterBlue.name` property that will
get the friendly bluetooth name of the local bluetooth adapter.

I tested this with my android application and it seems to be working just fine.

Please note that I did not test this under ios, Unfortunately I have no device to test it.
The code is inferred from reading the ios docs, but I'm happy to just leave it unimplemented or add a comment if it's hard to test.