### PR TITLE
[Android] BugFix add null check before calling method channel

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -40,7 +40,7 @@ android {
 
 protobuf {
     protoc {
-        artifact = 'com.google.protobuf:protoc:3.11.4'
+        artifact = 'com.google.protobuf:protoc:3.17.3'
     }
     generateProtoTasks {
         all().each { task ->
@@ -54,5 +54,5 @@ protobuf {
 }
 
 dependencies {
-    implementation 'com.google.protobuf:protobuf-javalite:3.11.4'
+    implementation 'com.google.protobuf:protobuf-javalite:3.17.3'
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -4,7 +4,7 @@ version '1.0'
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {
@@ -16,7 +16,7 @@ buildscript {
 rootProject.allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -3,4 +3,6 @@
     <uses-permission android:name="android.permission.BLUETOOTH" />
     <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
+    <uses-permission android:name="android.permission.BLUETOOTH_SCAN"/>
+    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT"/>
 </manifest>

--- a/android/src/main/java/com/pauldemarco/flutter_blue/FlutterBluePlugin.java
+++ b/android/src/main/java/com/pauldemarco/flutter_blue/FlutterBluePlugin.java
@@ -999,7 +999,9 @@ public class FlutterBluePlugin implements FlutterPlugin, ActivityAware, MethodCa
                 new Runnable() {
                     @Override
                     public void run() {
-                        channel.invokeMethod(name, byteArray);
+                        if(channel != null) {
+                            channel.invokeMethod(name, byteArray);
+                        }
                     }
                 });
     }

--- a/ios/Classes/FlutterBluePlugin.m
+++ b/ios/Classes/FlutterBluePlugin.m
@@ -65,12 +65,13 @@ typedef NS_ENUM(NSUInteger, LogLevel) {
   if(self.centralManager == nil){
     self.centralManager = [[CBCentralManager alloc] initWithDelegate:self queue:nil];
   }
-    
+
   if(self.centralManager.state == CBManagerStateUnknown){
     // Waiting for the CoreBluetooth to init, try again after 50 ms.
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.05 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
         [self handleMethodCall:call result:result];
     });
+    return;
   }
 
   if ([@"setLogLevel" isEqualToString:call.method]) {

--- a/ios/Classes/FlutterBluePlugin.m
+++ b/ios/Classes/FlutterBluePlugin.m
@@ -48,7 +48,6 @@ typedef NS_ENUM(NSUInteger, LogLevel) {
   FlutterEventChannel* stateChannel = [FlutterEventChannel eventChannelWithName:NAMESPACE @"/state" binaryMessenger:[registrar messenger]];
   FlutterBluePlugin* instance = [[FlutterBluePlugin alloc] init];
   instance.channel = channel;
-  instance.centralManager = [[CBCentralManager alloc] initWithDelegate:instance queue:nil];
   instance.scannedPeripherals = [NSMutableDictionary new];
   instance.servicesThatNeedDiscovered = [NSMutableArray new];
   instance.characteristicsThatNeedDiscovered = [NSMutableArray new];
@@ -63,6 +62,17 @@ typedef NS_ENUM(NSUInteger, LogLevel) {
 }
 
 - (void)handleMethodCall:(FlutterMethodCall*)call result:(FlutterResult)result {
+  if(self.centralManager == nil){
+    self.centralManager = [[CBCentralManager alloc] initWithDelegate:self queue:nil];
+  }
+    
+  if(self.centralManager.state == CBManagerStateUnknown){
+    // Waiting for the CoreBluetooth to init, try again after 50 ms.
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.05 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        [self handleMethodCall:call result:result];
+    });
+  }
+
   if ([@"setLogLevel" isEqualToString:call.method]) {
     NSNumber *logLevelIndex = [call arguments];
     _logLevel = (LogLevel)[logLevelIndex integerValue];

--- a/lib/src/flutter_blue.dart
+++ b/lib/src/flutter_blue.dart
@@ -187,8 +187,8 @@ class FlutterBlue {
   /// Messages equal or below the log level specified are stored/forwarded,
   /// messages above are dropped.
   void setLogLevel(LogLevel level) async {
-    await _channel.invokeMethod('setLogLevel', level.index);
     _logLevel = level;
+    await _channel.invokeMethod('setLogLevel', level.index);
   }
 
   void _log(LogLevel level, String message) {


### PR DESCRIPTION
Fix NULL exception crash on production app.

Exception java.lang.NullPointerException:
  at com.pauldemarco.flutter_blue.FlutterBluePlugin$5.run (FlutterBluePlugin.java:1002)
  at android.os.Handler.handleCallback (Handler.java:942)
  at android.os.Handler.dispatchMessage (Handler.java:99)
  at android.os.Looper.loopOnce (Looper.java:226)
  at android.os.Looper.loop (Looper.java:313)
  at android.app.ActivityThread.main (ActivityThread.java:8757)
  at java.lang.reflect.Method.invoke
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:571)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:1067)